### PR TITLE
chore(ci): harden GHA workflows with least-privilege permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,12 +3,21 @@ name: Compile module
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "compile"
   compile:
+    permissions:
+      contents: read
+
     name: Compile on ${{ matrix.os }} for nginx ${{ matrix.nginx_version }}
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -4,12 +4,14 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: write   # to upload release assets
-  id-token: write   # for cosign OIDC keyless signing
+permissions: {}
 
 jobs:
   package:
+    permissions:
+      contents: write   # to upload release assets
+      id-token: write   # for cosign OIDC keyless signing
+
     name: Package for nginx ${{ matrix.nginx_version }} (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
     env:
@@ -208,6 +210,8 @@ jobs:
             coraza-nginx_*_nginx${{ matrix.nginx_version }}_${{ matrix.arch }}.rpm.bundle
 
   install-test:
+    permissions:
+      contents: read
     name: Install test (${{ matrix.pkg_type }}, nginx ${{ matrix.nginx_version }}, ${{ matrix.arch }})
     needs: package
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,15 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   release-please:
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,8 +3,14 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions: {}
+
 jobs:
   stale:
+    permissions:
+      issues: write
+      pull-requests: write
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10


### PR DESCRIPTION
## Summary

Applies least-privilege permission hardening to all GitHub Actions workflows.

| Workflow | Changes |
|----------|---------|
| `build.yml` | Add `permissions: {}` top-level; add `contents: read` to `compile` job; scope `pull_request` and `push` triggers to `main` branch |
| `package.yml` | Move `contents: write` + `id-token: write` from top-level to `package` job; add `contents: read` to `install-test` job; set top-level to `permissions: {}` |
| `release.yml` | Move `contents: write`, `issues: write`, `pull-requests: write` from top-level to `release-please` job; set top-level to `permissions: {}` |
| `stale.yml` | Add `permissions: {}` top-level; add `issues: write` + `pull-requests: write` to `stale` job |