### PR TITLE
feat: add go-ftw e2e tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,6 +139,66 @@ jobs:
           export TEST_NGINX_GLOBALS="load_module \"/usr/lib/nginx/modules/ngx_http_coraza_module.so\";"
           prove coraza*.t
 
+      - name: Install go-ftw
+        run: go install github.com/coreruleset/go-ftw@latest
+
+      - name: Setup CRS and run go-ftw tests
+        run: |
+          # Download CRS
+          CRS_VERSION="4.25.0"
+          curl -sSL "https://github.com/coreruleset/coreruleset/archive/refs/tags/v${CRS_VERSION}.tar.gz" -o /tmp/crs.tar.gz
+          sudo mkdir -p /opt/coraza/owasp-crs /opt/coraza/config /opt/coraza/config.d /opt/coraza/plugins /opt/coraza/rules /opt/coraza/rules.d /opt/coraza/overrides
+          sudo tar xzf /tmp/crs.tar.gz -C /tmp
+          sudo cp -r /tmp/coreruleset-${CRS_VERSION}/rules /opt/coraza/owasp-crs/
+          sudo cp -r /tmp/coreruleset-${CRS_VERSION}/plugins /opt/coraza/owasp-crs/
+          sudo cp /tmp/coreruleset-${CRS_VERSION}/crs-setup.conf.example /opt/coraza/config/crs-setup.conf
+
+          # Create coraza config
+          sudo tee /opt/coraza/config/coraza.conf > /dev/null <<'CONF'
+          SecRuleEngine On
+          SecRequestBodyAccess On
+          SecResponseBodyAccess Off
+          SecAuditEngine Off
+          CONF
+
+          # Create rules include chain
+          sudo tee /opt/coraza/config/coraza-rules.conf > /dev/null <<'CONF'
+          Include /opt/coraza/config/coraza.conf
+          Include /opt/coraza/config.d/*.conf
+          Include /opt/coraza/config/crs-setup.conf
+          Include /opt/coraza/owasp-crs/plugins/*-config.conf
+          Include /opt/coraza/owasp-crs/plugins/*-before.conf
+          Include /opt/coraza/owasp-crs/rules/*.conf
+          Include /opt/coraza/owasp-crs/plugins/*-after.conf
+          Include /opt/coraza/plugins/*-config.conf
+          Include /opt/coraza/plugins/*-before.conf
+          Include /opt/coraza/plugins/*-after.conf
+          Include /opt/coraza/rules/*.conf
+          Include /opt/coraza/rules.d/*.conf
+          Include /opt/coraza/overrides/*.conf
+          CONF
+
+          # Install nginx test config and create directories
+          sudo cp tests/ftw/nginx-test.conf /etc/nginx/nginx.conf
+          sudo mkdir -p /var/cache/nginx/client_temp /var/log/nginx /tmp/empty
+          echo "OK" | sudo tee /tmp/empty/index.html > /dev/null
+
+          # Start nginx
+          sudo /usr/sbin/nginx
+          sleep 2
+
+          # Run go-ftw
+          cat > /tmp/.ftw.yaml <<'EOF'
+          testoverride:
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+          EOF
+          ~/go/bin/go-ftw run --cloud --config /tmp/.ftw.yaml -d tests/ftw/
+
+          # Stop nginx
+          sudo /usr/sbin/nginx -s stop
+
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,15 +140,18 @@ jobs:
           prove coraza*.t
 
       - name: Install go-ftw
-        run: go install github.com/coreruleset/go-ftw@latest
+        run: |
+          # renovate: depName=coreruleset/go-ftw datasource=github-releases
+          go install github.com/coreruleset/go-ftw/v2@v2.1.0
 
       - name: Setup CRS and run go-ftw tests
         run: |
           # Download CRS
+          # renovate: depName=coreruleset/coreruleset datasource=github-releases
           CRS_VERSION="4.25.0"
           curl -sSL "https://github.com/coreruleset/coreruleset/archive/refs/tags/v${CRS_VERSION}.tar.gz" -o /tmp/crs.tar.gz
           sudo mkdir -p /opt/coraza/owasp-crs /opt/coraza/config /opt/coraza/config.d /opt/coraza/plugins /opt/coraza/rules /opt/coraza/rules.d /opt/coraza/overrides
-          sudo tar xzf /tmp/crs.tar.gz -C /tmp
+          tar xzf /tmp/crs.tar.gz -C /tmp
           sudo cp -r /tmp/coreruleset-${CRS_VERSION}/rules /opt/coraza/owasp-crs/
           sudo cp -r /tmp/coreruleset-${CRS_VERSION}/plugins /opt/coraza/owasp-crs/
           sudo cp /tmp/coreruleset-${CRS_VERSION}/crs-setup.conf.example /opt/coraza/config/crs-setup.conf
@@ -183,9 +186,12 @@ jobs:
           sudo mkdir -p /var/cache/nginx/client_temp /var/log/nginx /tmp/empty
           echo "OK" | sudo tee /tmp/empty/index.html > /dev/null
 
-          # Start nginx
+          # Start nginx and wait for it
           sudo /usr/sbin/nginx
-          sleep 2
+          for i in $(seq 1 10); do
+            if [ -f /etc/nginx/logs/nginx.pid ]; then break; fi
+            sleep 1
+          done
 
           # Run go-ftw
           cat > /tmp/.ftw.yaml <<'EOF'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,60 +146,58 @@ jobs:
 
       - name: Setup CRS and run go-ftw tests
         run: |
-          # Download CRS
+          # Create directories owned by runner (avoids sudo for file operations)
+          sudo mkdir -p /opt/coraza /var/cache/nginx/client_temp /var/log/nginx
+          sudo chown -R $(id -u):$(id -g) /opt/coraza /var/cache/nginx /var/log/nginx
+          mkdir -p /opt/coraza/{owasp-crs,config,config.d,plugins,rules,rules.d,overrides} /tmp/empty
+
+          # Download and install CRS
           # renovate: depName=coreruleset/coreruleset datasource=github-releases
           CRS_VERSION="4.25.0"
           curl -sSL "https://github.com/coreruleset/coreruleset/archive/refs/tags/v${CRS_VERSION}.tar.gz" -o /tmp/crs.tar.gz
-          sudo mkdir -p /opt/coraza/owasp-crs /opt/coraza/config /opt/coraza/config.d /opt/coraza/plugins /opt/coraza/rules /opt/coraza/rules.d /opt/coraza/overrides
           tar xzf /tmp/crs.tar.gz -C /tmp
-          sudo cp -r /tmp/coreruleset-${CRS_VERSION}/rules /opt/coraza/owasp-crs/
-          sudo cp -r /tmp/coreruleset-${CRS_VERSION}/plugins /opt/coraza/owasp-crs/
-          sudo cp /tmp/coreruleset-${CRS_VERSION}/crs-setup.conf.example /opt/coraza/config/crs-setup.conf
+          cp -r /tmp/coreruleset-${CRS_VERSION}/rules /opt/coraza/owasp-crs/
+          cp -r /tmp/coreruleset-${CRS_VERSION}/plugins /opt/coraza/owasp-crs/
+          cp /tmp/coreruleset-${CRS_VERSION}/crs-setup.conf.example /opt/coraza/config/crs-setup.conf
 
           # Create coraza config
-          sudo tee /opt/coraza/config/coraza.conf > /dev/null <<'CONF'
-          SecRuleEngine On
-          SecRequestBodyAccess On
-          SecResponseBodyAccess Off
-          SecAuditEngine Off
-          CONF
+          printf '%s\n' \
+            'SecRuleEngine On' \
+            'SecRequestBodyAccess On' \
+            'SecResponseBodyAccess Off' \
+            'SecAuditEngine Off' \
+            > /opt/coraza/config/coraza.conf
 
           # Create rules include chain
-          sudo tee /opt/coraza/config/coraza-rules.conf > /dev/null <<'CONF'
-          Include /opt/coraza/config/coraza.conf
-          Include /opt/coraza/config.d/*.conf
-          Include /opt/coraza/config/crs-setup.conf
-          Include /opt/coraza/owasp-crs/plugins/*-config.conf
-          Include /opt/coraza/owasp-crs/plugins/*-before.conf
-          Include /opt/coraza/owasp-crs/rules/*.conf
-          Include /opt/coraza/owasp-crs/plugins/*-after.conf
-          Include /opt/coraza/plugins/*-config.conf
-          Include /opt/coraza/plugins/*-before.conf
-          Include /opt/coraza/plugins/*-after.conf
-          Include /opt/coraza/rules/*.conf
-          Include /opt/coraza/rules.d/*.conf
-          Include /opt/coraza/overrides/*.conf
-          CONF
+          printf '%s\n' \
+            'Include /opt/coraza/config/coraza.conf' \
+            'Include /opt/coraza/config.d/*.conf' \
+            'Include /opt/coraza/config/crs-setup.conf' \
+            'Include /opt/coraza/owasp-crs/plugins/*-config.conf' \
+            'Include /opt/coraza/owasp-crs/plugins/*-before.conf' \
+            'Include /opt/coraza/owasp-crs/rules/*.conf' \
+            'Include /opt/coraza/owasp-crs/plugins/*-after.conf' \
+            'Include /opt/coraza/plugins/*-config.conf' \
+            'Include /opt/coraza/plugins/*-before.conf' \
+            'Include /opt/coraza/plugins/*-after.conf' \
+            'Include /opt/coraza/rules/*.conf' \
+            'Include /opt/coraza/rules.d/*.conf' \
+            'Include /opt/coraza/overrides/*.conf' \
+            > /opt/coraza/config/coraza-rules.conf
 
-          # Install nginx test config and create directories
+          # Install nginx test config
           sudo cp tests/ftw/nginx-test.conf /etc/nginx/nginx.conf
-          sudo mkdir -p /var/cache/nginx/client_temp /var/log/nginx /tmp/empty
-          echo "OK" | sudo tee /tmp/empty/index.html > /dev/null
+          echo "OK" > /tmp/empty/index.html
 
-          # Start nginx and wait for it
+          # Start nginx (needs root for port 80) and wait for pidfile
           sudo /usr/sbin/nginx
           for i in $(seq 1 10); do
-            if [ -f /etc/nginx/logs/nginx.pid ]; then break; fi
+            if [ -f /tmp/nginx.pid ]; then break; fi
             sleep 1
           done
 
           # Run go-ftw
-          cat > /tmp/.ftw.yaml <<'EOF'
-          testoverride:
-            input:
-              dest_addr: "127.0.0.1"
-              port: 80
-          EOF
+          printf 'testoverride:\n  input:\n    dest_addr: "127.0.0.1"\n    port: 80\n' > /tmp/.ftw.yaml
           ~/go/bin/go-ftw run --cloud --config /tmp/.ftw.yaml -d tests/ftw/
 
           # Stop nginx

--- a/tests/ftw/attacks-rce.yaml
+++ b/tests/ftw/attacks-rce.yaml
@@ -5,13 +5,13 @@ meta:
 
 rule_id: 932100
 tests:
-  - test_title: "GET RCE: /etc/passwd"
+  - test_title: "GET RCE: command injection"
     stages:
       - input:
           headers:
             Host: "localhost"
           method: "GET"
-          uri: "/?cmd=/etc/passwd"
+          uri: "/?cmd=;cat%20/etc/passwd"
         output:
           status: 403
 

--- a/tests/ftw/attacks-rce.yaml
+++ b/tests/ftw/attacks-rce.yaml
@@ -1,0 +1,64 @@
+---
+meta:
+  author: "coraza"
+  description: "Remote Code Execution (RCE) detection across HTTP methods"
+
+rule_id: 932100
+tests:
+  - test_title: "GET RCE: /etc/passwd"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/?cmd=/etc/passwd"
+        output:
+          status: 403
+
+  - test_title: "POST RCE: shell command"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "POST"
+          uri: "/"
+          data: "cmd=;cat /etc/passwd"
+        output:
+          status: 403
+
+  - test_title: "POST RCE: pipe command"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "POST"
+          uri: "/"
+          data: "cmd=|ls -la"
+        output:
+          status: 403
+
+  - test_title: "PUT RCE: shell command"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "PUT"
+          uri: "/"
+          data: "cmd=;cat /etc/passwd"
+        output:
+          status: 403
+
+  - test_title: "DELETE RCE: shell command"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "DELETE"
+          uri: "/"
+          data: "cmd=;cat /etc/passwd"
+        output:
+          status: 403

--- a/tests/ftw/attacks-sqli.yaml
+++ b/tests/ftw/attacks-sqli.yaml
@@ -1,0 +1,120 @@
+---
+meta:
+  author: "coraza"
+  description: "SQL Injection detection across HTTP methods"
+
+rule_id: 942100
+tests:
+  - test_title: "GET SQLi: OR 1=1"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/?id=1%20OR%201%3D1"
+        output:
+          status: 403
+
+  - test_title: "GET SQLi: UNION SELECT"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/?id=1%20UNION%20SELECT%201,2,3"
+        output:
+          status: 403
+
+  - test_title: "GET normal request passes"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/"
+        output:
+          status: 200
+
+  - test_title: "POST SQLi: OR 1=1"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "POST"
+          uri: "/"
+          data: "id=1 OR 1=1"
+        output:
+          status: 403
+
+  - test_title: "POST SQLi: UNION SELECT"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "POST"
+          uri: "/"
+          data: "id=1 UNION SELECT 1,2,3"
+        output:
+          status: 403
+
+  - test_title: "POST SQLi: DROP TABLE"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "POST"
+          uri: "/"
+          data: "q=1;DROP TABLE users"
+        output:
+          status: 403
+
+  - test_title: "POST normal form passes"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "POST"
+          uri: "/"
+          data: "name=john&age=30"
+        output:
+          status: 200
+
+  - test_title: "POST normal JSON passes"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/json"
+          method: "POST"
+          uri: "/"
+          data: '{"user":"john","action":"login"}'
+        output:
+          status: 200
+
+  - test_title: "PUT SQLi: OR 1=1"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "PUT"
+          uri: "/"
+          data: "id=1 OR 1=1"
+        output:
+          status: 403
+
+  - test_title: "DELETE SQLi: OR 1=1"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "DELETE"
+          uri: "/"
+          data: "id=1 OR 1=1"
+        output:
+          status: 403

--- a/tests/ftw/attacks-xss.yaml
+++ b/tests/ftw/attacks-xss.yaml
@@ -1,0 +1,74 @@
+---
+meta:
+  author: "coraza"
+  description: "Cross-Site Scripting (XSS) detection across HTTP methods"
+
+rule_id: 941100
+tests:
+  - test_title: "GET XSS: script tag"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/?q=%3Cscript%3Ealert(1)%3C/script%3E"
+        output:
+          status: 403
+
+  - test_title: "GET XSS: img onerror"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/?q=%3Cimg%20src%3Dx%20onerror%3Dalert(1)%3E"
+        output:
+          status: 403
+
+  - test_title: "POST XSS: script tag"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "POST"
+          uri: "/"
+          data: "q=<script>alert(1)</script>"
+        output:
+          status: 403
+
+  - test_title: "POST XSS: img onerror"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "POST"
+          uri: "/"
+          data: "q=<img src=x onerror=alert(1)>"
+        output:
+          status: 403
+
+  - test_title: "PUT XSS: script tag"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "PUT"
+          uri: "/"
+          data: "q=<script>alert(1)</script>"
+        output:
+          status: 403
+
+  - test_title: "DELETE XSS: script tag"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "DELETE"
+          uri: "/"
+          data: "q=<script>alert(1)</script>"
+        output:
+          status: 403

--- a/tests/ftw/config-merge.yaml
+++ b/tests/ftw/config-merge.yaml
@@ -1,0 +1,48 @@
+---
+meta:
+  author: "coraza"
+  description: "Config merging and override tests"
+
+rule_id: 20010
+tests:
+  - test_title: "Engine off: SQLi passes"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/merge-engine-off?id=1%20OR%201%3D1"
+        output:
+          status: 200
+
+  - test_title: "Body access off: POST SQLi passes"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "POST"
+          uri: "/merge-bodyaccess-off/"
+          data: "id=1 OR 1=1"
+        output:
+          status: 200
+
+  - test_title: "Inherited location: local rule blocks"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/merge-inherited?localonly=yes"
+        output:
+          status: 403
+
+  - test_title: "Inherited location: CRS still active"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/merge-inherited?id=1%20OR%201%3D1"
+        output:
+          status: 403

--- a/tests/ftw/nginx-test.conf
+++ b/tests/ftw/nginx-test.conf
@@ -1,0 +1,110 @@
+load_module "/usr/lib/nginx/modules/ngx_http_coraza_module.so";
+
+worker_processes auto;
+error_log /dev/stderr warn;
+pid /tmp/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    coraza on;
+    coraza_rules_file /opt/coraza/config/coraza-rules.conf;
+
+    server {
+        listen 80 default_server;
+
+        # Default: serve a simple response via echo-like approach
+        # Using a small internal redirect to an always-200 backend
+        location @fallback {
+            return 200 "OK\n";
+        }
+
+        location / {
+            error_page 404 405 = @fallback;
+            root /tmp/empty;
+        }
+
+        location /phase1 {
+            coraza_rules '
+                SecRule ARGS:action "@streq block403" "id:20001,phase:1,deny,status:403,log"
+            ';
+            error_page 404 = @fallback;
+            root /tmp/empty;
+        }
+
+        location /phase2 {
+            coraza_rules '
+                SecRule REQUEST_BODY "@contains PHASE2ATTACK" "id:20002,phase:2,deny,status:403,log"
+            ';
+            error_page 404 = @fallback;
+            root /tmp/empty;
+        }
+
+        location /redirect-302 {
+            coraza_rules '
+                SecRule ARGS:target "@streq redirect" "id:20701,phase:1,status:302,log,redirect:http://www.coraza.io"
+            ';
+            error_page 404 = @fallback;
+            root /tmp/empty;
+        }
+
+        location /redirect-301 {
+            coraza_rules '
+                SecRule ARGS:target "@streq redirect" "id:20702,phase:1,status:301,log,redirect:http://www.coraza.io"
+            ';
+            error_page 404 = @fallback;
+            root /tmp/empty;
+        }
+
+        location /deny-401 {
+            coraza_rules '
+                SecRule ARGS:action "@streq block" "id:20401,phase:1,deny,status:401,log"
+            ';
+            error_page 404 = @fallback;
+            root /tmp/empty;
+        }
+
+        location /merge-engine-off {
+            coraza_rules 'SecRuleEngine Off';
+            error_page 404 = @fallback;
+            root /tmp/empty;
+        }
+
+        location /merge-bodyaccess-off {
+            coraza_rules 'SecRequestBodyAccess Off';
+            error_page 404 = @fallback;
+            root /tmp/empty;
+        }
+
+        location /merge-inherited {
+            coraza_rules '
+                SecRule ARGS:localonly "@streq yes" "id:20010,phase:1,deny,status:403,log"
+            ';
+            error_page 404 = @fallback;
+            root /tmp/empty;
+        }
+
+        location /scoring-absolute {
+            coraza_rules '
+                SecRule ARGS "@streq badarg1" "id:20101,phase:2,pass,setvar:tx.score=1"
+                SecRule ARGS "@streq badarg2" "id:20102,phase:2,pass,setvar:tx.score=2"
+                SecRule TX:SCORE "@ge 2" "id:20199,phase:2,deny,log,status:403"
+            ';
+            error_page 404 = @fallback;
+            root /tmp/empty;
+        }
+
+        location /scoring-iterative {
+            coraza_rules '
+                SecRule ARGS "@streq badarg1" "id:20201,phase:2,pass,setvar:tx.score=+1"
+                SecRule ARGS "@streq badarg2" "id:20202,phase:2,pass,setvar:tx.score=+1"
+                SecRule ARGS "@streq badarg3" "id:20203,phase:2,pass,setvar:tx.score=+1"
+                SecRule TX:SCORE "@ge 3" "id:20299,phase:2,deny,log,status:403"
+            ';
+            error_page 404 = @fallback;
+            root /tmp/empty;
+        }
+    }
+}

--- a/tests/ftw/nginx-test.conf
+++ b/tests/ftw/nginx-test.conf
@@ -30,7 +30,7 @@ http {
             coraza_rules '
                 SecRule ARGS:action "@streq block403" "id:20001,phase:1,deny,status:403,log"
             ';
-            error_page 404 = @fallback;
+            error_page 404 405 = @fallback;
             root /tmp/empty;
         }
 
@@ -38,7 +38,7 @@ http {
             coraza_rules '
                 SecRule REQUEST_BODY "@contains PHASE2ATTACK" "id:20002,phase:2,deny,status:403,log"
             ';
-            error_page 404 = @fallback;
+            error_page 404 405 = @fallback;
             root /tmp/empty;
         }
 
@@ -46,7 +46,7 @@ http {
             coraza_rules '
                 SecRule ARGS:target "@streq redirect" "id:20701,phase:1,status:302,log,redirect:http://www.coraza.io"
             ';
-            error_page 404 = @fallback;
+            error_page 404 405 = @fallback;
             root /tmp/empty;
         }
 
@@ -54,7 +54,7 @@ http {
             coraza_rules '
                 SecRule ARGS:target "@streq redirect" "id:20702,phase:1,status:301,log,redirect:http://www.coraza.io"
             ';
-            error_page 404 = @fallback;
+            error_page 404 405 = @fallback;
             root /tmp/empty;
         }
 
@@ -62,19 +62,19 @@ http {
             coraza_rules '
                 SecRule ARGS:action "@streq block" "id:20401,phase:1,deny,status:401,log"
             ';
-            error_page 404 = @fallback;
+            error_page 404 405 = @fallback;
             root /tmp/empty;
         }
 
         location /merge-engine-off {
             coraza_rules 'SecRuleEngine Off';
-            error_page 404 = @fallback;
+            error_page 404 405 = @fallback;
             root /tmp/empty;
         }
 
         location /merge-bodyaccess-off {
             coraza_rules 'SecRequestBodyAccess Off';
-            error_page 404 = @fallback;
+            error_page 404 405 = @fallback;
             root /tmp/empty;
         }
 
@@ -82,7 +82,7 @@ http {
             coraza_rules '
                 SecRule ARGS:localonly "@streq yes" "id:20010,phase:1,deny,status:403,log"
             ';
-            error_page 404 = @fallback;
+            error_page 404 405 = @fallback;
             root /tmp/empty;
         }
 
@@ -92,7 +92,7 @@ http {
                 SecRule ARGS "@streq badarg2" "id:20102,phase:2,pass,setvar:tx.score=2"
                 SecRule TX:SCORE "@ge 2" "id:20199,phase:2,deny,log,status:403"
             ';
-            error_page 404 = @fallback;
+            error_page 404 405 = @fallback;
             root /tmp/empty;
         }
 
@@ -103,7 +103,7 @@ http {
                 SecRule ARGS "@streq badarg3" "id:20203,phase:2,pass,setvar:tx.score=+1"
                 SecRule TX:SCORE "@ge 3" "id:20299,phase:2,deny,log,status:403"
             ';
-            error_page 404 = @fallback;
+            error_page 404 405 = @fallback;
             root /tmp/empty;
         }
     }

--- a/tests/ftw/phases.yaml
+++ b/tests/ftw/phases.yaml
@@ -1,0 +1,74 @@
+---
+meta:
+  author: "coraza"
+  description: "Phase 1 and 2 rule evaluation"
+
+rule_id: 20001
+tests:
+  - test_title: "Phase 1: block 403"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/phase1?action=block403"
+        output:
+          status: 403
+
+  - test_title: "Phase 1: normal passes"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/phase1?action=safe"
+        output:
+          status: 200
+
+  - test_title: "Phase 2: deny on body"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "POST"
+          uri: "/phase2"
+          data: "PHASE2ATTACK"
+        output:
+          status: 403
+
+  - test_title: "Phase 2: clean body passes"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "POST"
+          uri: "/phase2"
+          data: "cleandata"
+        output:
+          status: 200
+
+  - test_title: "Phase 2: PUT deny on body"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "PUT"
+          uri: "/phase2"
+          data: "PHASE2ATTACK"
+        output:
+          status: 403
+
+  - test_title: "Phase 2: DELETE deny on body"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "DELETE"
+          uri: "/phase2"
+          data: "PHASE2ATTACK"
+        output:
+          status: 403

--- a/tests/ftw/redirects.yaml
+++ b/tests/ftw/redirects.yaml
@@ -1,0 +1,46 @@
+---
+meta:
+  author: "coraza"
+  description: "Redirect and block status code tests"
+
+rule_id: 20701
+tests:
+  - test_title: "Redirect 302"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/redirect-302?target=redirect"
+        output:
+          status: 302
+
+  - test_title: "Redirect 301"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/redirect-301?target=redirect"
+        output:
+          status: 301
+
+  - test_title: "Block 401"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/deny-401?action=block"
+        output:
+          status: 401
+
+  - test_title: "Redirect: no match passes"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/redirect-302?target=safe"
+        output:
+          status: 200

--- a/tests/ftw/scoring.yaml
+++ b/tests/ftw/scoring.yaml
@@ -1,0 +1,56 @@
+---
+meta:
+  author: "coraza"
+  description: "Anomaly scoring tests"
+
+rule_id: 20199
+tests:
+  - test_title: "Absolute scoring: score=1 passes"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/scoring-absolute?what=badarg1"
+        output:
+          status: 200
+
+  - test_title: "Absolute scoring: score=2 blocks"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/scoring-absolute?what=badarg2"
+        output:
+          status: 403
+
+  - test_title: "Iterative scoring: 1 arg passes"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/scoring-iterative?arg1=badarg1"
+        output:
+          status: 200
+
+  - test_title: "Iterative scoring: 2 args passes"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/scoring-iterative?arg1=badarg1&arg2=badarg2"
+        output:
+          status: 200
+
+  - test_title: "Iterative scoring: 3 args blocks"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/scoring-iterative?arg1=badarg1&arg2=badarg2&arg3=badarg3"
+        output:
+          status: 403


### PR DESCRIPTION
Add 40 go-ftw tests running after the existing Perl test suite. Tests cover attack detection (SQLi, XSS, RCE), phase evaluation, redirects, scoring, and config merging.

CRS 4.25.0 is downloaded at test time. Tests run in cloud mode (HTTP status checks only).

Addresses #33

Note: coraza-caddy already runs the full CRS regression test suite via go-ftw. Should we do the same here, or are these custom tests enough for now?

cc @fzipi @jptosso

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive FTW test suites covering RCE, SQL injection, XSS, configuration-merge, phase handling, redirects, and anomaly scoring across multiple HTTP methods.

* **Chores**
  * CI now stages a local test server with OWASP CRS, runs the FTW validation suite against it, and cleans up test resources afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->