### PR TITLE
ci: add full CRS regression tests via go-ftw

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,9 +196,12 @@ jobs:
             sleep 1
           done
 
-          # Run go-ftw
+          # Run custom go-ftw tests
           printf 'testoverride:\n  input:\n    dest_addr: "127.0.0.1"\n    port: 80\n' > /tmp/.ftw.yaml
           ~/go/bin/go-ftw run --cloud --config /tmp/.ftw.yaml -d tests/ftw/
+
+          # Run full CRS regression tests
+          ~/go/bin/go-ftw run --cloud --config tests/ftw-crs.yml -d /tmp/coreruleset-${CRS_VERSION}/tests/regression/tests/ --exclude "^920"
 
           # Stop nginx
           sudo /usr/sbin/nginx -s stop

--- a/tests/ftw-crs.yml
+++ b/tests/ftw-crs.yml
@@ -1,0 +1,26 @@
+testoverride:
+  input:
+    dest_addr: "127.0.0.1"
+    port: 80
+  ignore:
+    # Imported from coraza upstream testing + nginx-specific
+    920100-4: 'Invalid uri, coraza not reached'
+    920100-5: 'Invalid uri, coraza not reached'
+    920100-8: 'Colon in path, nginx allows it unlike Apache'
+    920270-4: 'Rule works but test expects status 400'
+    920290-1: 'Rule works but test expects status 400'
+    920430-5: 'Test has expect_error'
+    920430-8: 'HTTP/3.0 not supported'
+    921250-1: 'Expected to match $Version in cookies, failing also in upstream'
+    921250-2: 'Expected to match $Version in cookies, failing also in upstream'
+    933120-2: 'To be investigated: match_regex value might be ModSec specific'
+    920274-1: ''
+    920280-3: ''
+    920290-4: 'test related to empty host header'
+    920430-3: 'expect_error: true'
+    920430-9: ''
+    920610-2: ''
+    920620-1: ''
+    922130-1: ''
+    922130-2: ''
+    922130-7: ''


### PR DESCRIPTION
## Summary
- Run the full CRS 4.25 regression test suite (excluding 920 protocol enforcement) against nginx+Coraza using go-ftw in cloud mode
- Reuses the existing CRS download and nginx setup from CI
- 920 tests excluded because some malformed HTTP requests crash the go-ftw connection through nginx

## Test plan
- CI passes

cc @jcchavezs