### PR TITLE
fix(header_filter): only delay response headers when body inspection is needed

### DIFF
--- a/src/ngx_http_coraza_header_filter.c
+++ b/src/ngx_http_coraza_header_filter.c
@@ -506,16 +506,21 @@ ngx_http_coraza_header_filter(ngx_http_request_t *r)
      * (SecResponseBodyAccess Off or Content-Type mismatch): in that case
      * there is no phase-4 buffering and the response must not be held back.
      */
-    if (!r->header_only && !r->error_page && r == r->main)
+    if (!r->header_only && !r->error_page && r == r->main
+        && ctx->response_body_processable)
     {
         /*
          * Delay sending headers until phase 4 completes so that
          * phase 4 rules can still return a clean error page.
-         * Only force body into memory when body inspection is needed.
+         *
+         * Only do this when body inspection is actually needed.  When it is
+         * not (SecResponseBodyAccess Off or Content-Type mismatch) the body
+         * filter does no phase-4 buffering, so holding the headers back would
+         * accumulate the entire response in the request pool before forwarding
+         * anything -- unbounded worker memory on large responses and broken
+         * streaming/SSE.  In that case forward the headers immediately.
          */
-        if (ctx->response_body_processable) {
-            r->filter_need_in_memory = 1;
-        }
+        r->filter_need_in_memory = 1;
         ctx->headers_delayed = 1;
         ctx->pending_chain = NULL;
         ctx->pending_chain_last = &ctx->pending_chain;

--- a/t/coraza-response-body.t
+++ b/t/coraza-response-body.t
@@ -59,6 +59,20 @@ http {
                 SecResponseBodyAccess Off
             ';
         }
+
+        # Streaming (unknown-length) response with body inspection Off.
+        # SSI processing makes nginx emit the response without a
+        # Content-Length (content_length_n == -1).  The connector must
+        # forward the response headers immediately instead of holding them
+        # back and accumulating the whole body in the request pool.
+        location /stream_access_off {
+            default_type text/html;
+            ssi on;
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess Off
+            ';
+        }
     }
 }
 EOF
@@ -72,9 +86,18 @@ $t->write_file("/body1", "BAD BODY");
 my $large_body = "X" x (100 * 1024);
 $t->write_file("/body_access_off", $large_body);
 
+# Unknown-length streaming body (SSI -> no Content-Length).  Exercises the
+# "delay skipped when body inspection is not needed" path: with the fix the
+# headers are forwarded immediately; without it the connector delayed the
+# headers and buffered the entire response in the request pool.
+my $stream_marker = "STREAMEND";
+my $stream_body = ("Y" x (100 * 1024)) . $stream_marker;
+$t->write_file("/stream_access_off",
+	'<!--# echo var="uri" -->' . $stream_body);
+
 $t->run();
 $t->todo_alerts();
-$t->plan(3);
+$t->plan(5);
 
 ###############################################################################
 
@@ -83,4 +106,17 @@ like(http_get('/body1'), qr/^HTTP.*403/, 'response body (block)');
 my $r = http_get('/body_access_off');
 like($r, qr/^HTTP.*200/, 'large response with SecResponseBodyAccess Off returns 200');
 like($r, qr/\Q$large_body\E/, 'large response body delivered intact');
+
+# HTTP/1.1 so the unknown-length SSI response is streamed (chunked) rather
+# than buffered into a Content-Length by the HTTP/1.0 path.
+my $s = http(<<EOF);
+GET /stream_access_off HTTP/1.1
+Host: localhost
+Connection: close
+
+EOF
+like($s, qr/^HTTP.*200/,
+	'streaming (no Content-Length) response with Access Off returns 200');
+like($s, qr/\Q$stream_marker\E/,
+	'streaming response body delivered intact end-to-end');
 


### PR DESCRIPTION
We package and ship the Coraza nginx module on https://deb.myguard.nl/nginx-modules. We run a code audit on every new module we add to the stack, and this fix came out of that audit. Sending it upstream.


ctx->headers_delayed was set unconditionally for main, non-error, non-header-only responses, while only filter_need_in_memory was gated on ctx->response_body_processable.

When body inspection is not needed (SecResponseBodyAccess Off or a Content-Type that does not match SecResponseBodyMimeType), the body filter performs no phase-4 buffering. Delaying the headers anyway caused the body filter to accumulate every response buffer into the request pool and forward nothing until the last buffer:

  - unbounded worker memory: a multi-GB static file or proxied download is copied whole into the request pool before the client sees any byte;
  - broken streaming / SSE: chunked (content_length_n == -1) responses are held until complete, with no time-to-first-byte.

Gate the whole delay on ctx->response_body_processable so the headers are forwarded immediately when there is nothing to inspect, matching the intent already described in the surrounding comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved response header filtering logic to better handle deferred header forwarding during response body inspection.

* **Tests**
  * Added test coverage for streaming responses with response body access disabled, including validation of end-to-end payload delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->