### PR TITLE
fix(module): do not allocate an unused cleanup data buffer per request

### DIFF
--- a/src/ngx_http_coraza_module.c
+++ b/src/ngx_http_coraza_module.c
@@ -175,7 +175,7 @@ ngx_http_coraza_create_ctx(ngx_http_request_t *r)
 
 	ngx_http_set_ctx(r, ctx, ngx_http_coraza_module);
 
-	cln = ngx_pool_cleanup_add(r->pool, sizeof(ngx_http_coraza_ctx_t));
+	cln = ngx_pool_cleanup_add(r->pool, 0);
 	if (cln == NULL)
 	{
 		dd("failed to create the CORAZA context cleanup");


### PR DESCRIPTION
We package and ship the Coraza nginx module on https://deb.myguard.nl/nginx-modules. We run a code audit on every new module we add to the stack, and this fix came out of that audit. Sending it upstream.

ngx_http_coraza_create_ctx registered the transaction cleanup with ngx_pool_cleanup_add(r->pool, sizeof(ngx_http_coraza_ctx_t)). The size argument makes the pool allocate a data buffer of that size and point cln->data at it -- but the very next line overwrites cln->data with the already-allocated ctx, so the buffer is dead weight allocated on every request.

The cleanup handler only needs cln->data to reference the existing ctx, so pass 0 (no extra allocation), matching the standard nginx idiom for this case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal resource cleanup behavior to reduce unnecessary memory allocation during context teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->