### PR TITLE
fix(header_filter): pass Content-Length: 0 to the WAF for inspection

### DIFF
--- a/src/ngx_http_coraza_header_filter.c
+++ b/src/ngx_http_coraza_header_filter.c
@@ -136,7 +136,7 @@ ngx_http_coraza_resolv_header_content_length(ngx_http_request_t *r, ngx_str_t na
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_coraza_module);
 
-    if (r->headers_out.content_length_n > 0)
+    if (r->headers_out.content_length_n >= 0)
     {
         ngx_sprintf((u_char *)buf, "%O%Z", r->headers_out.content_length_n);
         value.data = (unsigned char *)buf;

--- a/t/coraza-response-content-length.t
+++ b/t/coraza-response-content-length.t
@@ -1,0 +1,84 @@
+#!/usr/bin/perl
+
+# Tests for Coraza-nginx connector (Content-Length response header).
+#
+# Regression test for the fix that forwards a zero-length Content-Length
+# response header to the WAF.  Previously the connector only passed
+# Content-Length to Coraza when content_length_n > 0, so a legitimate
+# Content-Length: 0 body was never surfaced and could not be matched by a
+# RESPONSE_HEADERS rule.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http/);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        coraza on;
+
+        # Deny when the response carries Content-Length: 0.  This only fires
+        # if the connector forwarded the zero-length Content-Length header to
+        # the engine.
+        location /empty {
+            default_type text/plain;
+            coraza_rules '
+                SecRuleEngine On
+                SecRule RESPONSE_HEADERS:Content-Length "@streq 0" "id:31,phase:3,deny,log,status:403"
+            ';
+        }
+
+        # Control: a non-zero Content-Length must not match the rule above.
+        location /nonempty {
+            default_type text/plain;
+            coraza_rules '
+                SecRuleEngine On
+                SecRule RESPONSE_HEADERS:Content-Length "@streq 0" "id:32,phase:3,deny,log,status:403"
+            ';
+        }
+    }
+}
+EOF
+
+$t->write_file("/empty", "");
+$t->write_file("/nonempty", "hello");
+
+$t->run();
+$t->todo_alerts();
+$t->plan(2);
+
+###############################################################################
+
+like(http_get('/empty'), qr/^HTTP.*403/,
+	'Content-Length: 0 response header inspected (block)');
+
+like(http_get('/nonempty'), qr/^HTTP.*200/,
+	'non-zero Content-Length does not match the zero-length rule');


### PR DESCRIPTION
We package and ship the Coraza nginx module on https://deb.myguard.nl/nginx-modules. We run a code audit on every new module we add to the stack, and this fix came out of that audit. Sending it upstream.


ngx_http_coraza_resolv_header_content_length only forwarded the Content-Length response header to Coraza when content_length_n > 0, so a legitimate zero-length body (Content-Length: 0) was never surfaced to the engine and could not be matched by response-header rules.

content_length_n is -1 when the length is unknown/unset, so >= 0 correctly includes a real 0 while still excluding the unknown case. ngx_sprintf("%O") formats 0 as "0".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed response header handling to properly forward `Content-Length: 0` to the WAF engine for rule evaluation.

* **Tests**
  * Added regression test validating `Content-Length: 0` response header forwarding and WAF rule matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->