### PR TITLE
fix: skip deleted (hash == 0) headers when collecting them for coraza

### DIFF
--- a/src/ngx_http_coraza_header_filter.c
+++ b/src/ngx_http_coraza_header_filter.c
@@ -393,6 +393,12 @@ ngx_http_coraza_header_filter(ngx_http_request_t *r)
             i = 0;
         }
 
+        /* skip deleted headers (hash == 0): their key/value pointers may be
+         * stale, like nginx does in its own header filter */
+        if (data[i].hash == 0) {
+            continue;
+        }
+
 #if defined(CORAZA_SANITY_CHECKS) && (CORAZA_SANITY_CHECKS)
         ngx_http_coraza_store_ctx_header(r, &data[i].key, &data[i].value);
 #endif

--- a/src/ngx_http_coraza_rewrite.c
+++ b/src/ngx_http_coraza_rewrite.c
@@ -164,6 +164,12 @@ ngx_http_coraza_rewrite_handler(ngx_http_request_t *r)
                 i = 0;
             }
 
+            /* skip deleted headers (hash == 0): their key/value pointers
+             * may be stale */
+            if (data[i].hash == 0) {
+                continue;
+            }
+
             /**
              * By using u_char (utf8_t) I believe nginx is hoping to deal
              * with utf8 strings.


### PR DESCRIPTION
nginx can leave invalidated entries (`hash == 0`) in its request/response header lists. The connector walks the whole list and forwards every entry's key/value pointers to coraza, including the deleted ones whose pointers may be stale.

nginx skips `hash == 0` entries in its own header filter; this does the same in both the request loop (`rewrite`) and the response loop (`header_filter`).

Defensive hardening — not tied to a specific reported crash.
