### PR TITLE
fix: require libcoraza 1.4 ABI

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Rules-Requires-Root: no
 
 Package: libnginx-mod-http-coraza
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, libcoraza1
+Depends: ${misc:Depends}, ${shlibs:Depends}, libcoraza1 (>= 1.4.0)
 Description: Coraza WAF connector module for nginx
  Coraza is an open-source Web Application Firewall (WAF) engine.
  This module integrates the Coraza WAF with the nginx web server,

--- a/src/ngx_http_coraza_dl.c
+++ b/src/ngx_http_coraza_dl.c
@@ -46,7 +46,7 @@ typedef int                  (*fn_coraza_process_logging)(coraza_transaction_t);
 typedef int                  (*fn_coraza_update_status_code)(coraza_transaction_t, int);
 typedef int                  (*fn_coraza_add_get_args)(coraza_transaction_t, char *, char *);
 
-/* Optional — present in libcoraza 1.4+.  Returns 1 if the response body
+/* Present in libcoraza 1.4+.  Returns 1 if the response body
  * should be inspected (SecResponseBodyAccess On and Content-Type matches
  * SecResponseBodyMimeType).  Must be called after
  * coraza_process_response_headers(). */
@@ -84,7 +84,6 @@ static fn_coraza_process_logging         dl_process_logging;
 static fn_coraza_update_status_code      dl_update_status_code;
 static fn_coraza_add_get_args            dl_add_get_args;
 
-/* Optional — NULL when using libcoraza < 1.4 */
 static fn_coraza_is_response_body_processable dl_is_response_body_processable;
 
 static dynlib_t dl_handle;
@@ -333,7 +332,7 @@ int coraza_add_get_args(coraza_transaction_t t, char *name,
 
 /*
  * ngx_http_coraza_is_response_body_processable — wrapper around the
- * optional coraza_is_response_body_processable symbol.
+ * coraza_is_response_body_processable symbol.
  *
  * Returns 1 if the response body should be inspected for this transaction
  * (i.e. SecResponseBodyAccess is On and the Content-Type matches

--- a/t/coraza-dynlib-contract.t
+++ b/t/coraza-dynlib-contract.t
@@ -26,7 +26,7 @@ unlike($dl, qr/Optional.*coraza_is_response_body_processable/s,
 unlike($dl, qr/libcoraza\s*<\s*1\.4/,
 	'loader comments do not advertise pre-1.4 compatibility');
 
-like($dl, qr/DL_SYM\(dl_is_response_body_processable,\s*\n\s*coraza_is_response_body_processable\)/,
+like($dl, qr/DL_SYM\(dl_is_response_body_processable,\s*coraza_is_response_body_processable\)/s,
 	'response-body helper is resolved as a required symbol');
 
 done_testing();

--- a/t/coraza-dynlib-contract.t
+++ b/t/coraza-dynlib-contract.t
@@ -1,0 +1,41 @@
+#!/usr/bin/perl
+
+# Static contract checks for the libcoraza dlopen boundary.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+use FindBin;
+
+###############################################################################
+
+my $root = "$FindBin::Bin/..";
+
+my $control = slurp("$root/debian/control");
+my $dl = slurp("$root/src/ngx_http_coraza_dl.c");
+
+like($control, qr/\blibcoraza1\s+\(>=\s*1\.4\.0\)/,
+	'Debian package pins the libcoraza runtime ABI');
+
+unlike($dl, qr/Optional.*coraza_is_response_body_processable/s,
+	'response-body helper is not documented as optional');
+
+unlike($dl, qr/libcoraza\s*<\s*1\.4/,
+	'loader comments do not advertise pre-1.4 compatibility');
+
+like($dl, qr/DL_SYM\(dl_is_response_body_processable,\s*\n\s*coraza_is_response_body_processable\)/,
+	'response-body helper is resolved as a required symbol');
+
+done_testing();
+
+###############################################################################
+
+sub slurp {
+	my ($path) = @_;
+	open my $fh, '<', $path or die "open $path: $!";
+	local $/ = undef;
+	return <$fh>;
+}


### PR DESCRIPTION
Part of an 18-PR hardening series (numbered 01–18); each PR is independent against main, recommended review order is numeric.

**Severity:** Low

## What
Pin the runtime dependency to `libcoraza1 (>= 1.4.0)` in `debian/control`.

## Why
The connector requires the `coraza_is_response_body_processable` symbol, which only exists in libcoraza 1.4+. With a bare `libcoraza1` dependency the package installs against 1.3 and the module fails at dlopen time with an unresolved symbol instead of a clean dependency error.

## Testing
Adds a static contract test that keeps `debian/control` and the dlopen boundary in `ngx_http_coraza_dl.c` in sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the module’s dependency to require `libcoraza1` version **>= 1.4.0**.
  * Clarified that response-body processing support is **required** for supported versions.

* **Tests**
  * Added a contract test to ensure package metadata and loader expectations remain consistent with the supported runtime version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->