### PR TITLE
fix: drop unused Coraza dl symbols

### DIFF
--- a/src/ngx_http_coraza_dl.c
+++ b/src/ngx_http_coraza_dl.c
@@ -25,7 +25,6 @@ typedef int                  (*fn_coraza_free_waf_config)(coraza_waf_config_t);
 typedef coraza_waf_t         (*fn_coraza_new_waf)(coraza_waf_config_t, char **);
 typedef int                  (*fn_coraza_free_waf)(coraza_waf_t);
 typedef int                  (*fn_coraza_rules_count)(coraza_waf_t);
-typedef int                  (*fn_coraza_rules_merge)(coraza_waf_t, coraza_waf_t, char **);
 typedef coraza_transaction_t (*fn_coraza_new_transaction)(coraza_waf_t);
 typedef coraza_transaction_t (*fn_coraza_new_transaction_with_id)(coraza_waf_t, char *);
 typedef int                  (*fn_coraza_free_transaction)(coraza_transaction_t);
@@ -44,7 +43,6 @@ typedef int                  (*fn_coraza_process_response_body)(coraza_transacti
 typedef int                  (*fn_coraza_process_response_headers)(coraza_transaction_t, int, char *);
 typedef int                  (*fn_coraza_process_logging)(coraza_transaction_t);
 typedef int                  (*fn_coraza_update_status_code)(coraza_transaction_t, int);
-typedef int                  (*fn_coraza_add_get_args)(coraza_transaction_t, char *, char *);
 
 /* Optional — present in libcoraza 1.4+.  Returns 1 if the response body
  * should be inspected (SecResponseBodyAccess On and Content-Type matches
@@ -63,7 +61,6 @@ static fn_coraza_free_waf_config         dl_free_waf_config;
 static fn_coraza_new_waf                 dl_new_waf;
 static fn_coraza_free_waf                dl_free_waf;
 static fn_coraza_rules_count             dl_rules_count;
-static fn_coraza_rules_merge             dl_rules_merge;
 static fn_coraza_new_transaction         dl_new_transaction;
 static fn_coraza_new_transaction_with_id dl_new_transaction_with_id;
 static fn_coraza_free_transaction        dl_free_transaction;
@@ -82,7 +79,6 @@ static fn_coraza_process_response_body   dl_process_response_body;
 static fn_coraza_process_response_headers dl_process_response_headers;
 static fn_coraza_process_logging         dl_process_logging;
 static fn_coraza_update_status_code      dl_update_status_code;
-static fn_coraza_add_get_args            dl_add_get_args;
 
 /* Optional — NULL when using libcoraza < 1.4 */
 static fn_coraza_is_response_body_processable dl_is_response_body_processable;
@@ -134,7 +130,6 @@ ngx_http_coraza_dl_open(ngx_log_t *log)
     DL_SYM(dl_new_waf,                  coraza_new_waf);
     DL_SYM(dl_free_waf,                 coraza_free_waf);
     DL_SYM(dl_rules_count,              coraza_rules_count);
-    DL_SYM(dl_rules_merge,              coraza_rules_merge);
     DL_SYM(dl_new_transaction,           coraza_new_transaction);
     DL_SYM(dl_new_transaction_with_id,   coraza_new_transaction_with_id);
     DL_SYM(dl_free_transaction,          coraza_free_transaction);
@@ -153,7 +148,6 @@ ngx_http_coraza_dl_open(ngx_log_t *log)
     DL_SYM(dl_process_response_headers, coraza_process_response_headers);
     DL_SYM(dl_process_logging,          coraza_process_logging);
     DL_SYM(dl_update_status_code,       coraza_update_status_code);
-    DL_SYM(dl_add_get_args,             coraza_add_get_args);
 
     DL_SYM(dl_is_response_body_processable,
            coraza_is_response_body_processable);
@@ -220,11 +214,6 @@ int coraza_free_waf(coraza_waf_t w)
 int coraza_rules_count(coraza_waf_t w)
 {
     return dl_rules_count(w);
-}
-
-int coraza_rules_merge(coraza_waf_t w1, coraza_waf_t w2, char **err)
-{
-    return dl_rules_merge(w1, w2, err);
 }
 
 coraza_transaction_t coraza_new_transaction(coraza_waf_t w)
@@ -323,12 +312,6 @@ int coraza_process_logging(coraza_transaction_t t)
 int coraza_update_status_code(coraza_transaction_t t, int code)
 {
     return dl_update_status_code(t, code);
-}
-
-int coraza_add_get_args(coraza_transaction_t t, char *name,
-                        char *value)
-{
-    return dl_add_get_args(t, name, value);
 }
 
 /*

--- a/t/coraza-dynlib-contract.t
+++ b/t/coraza-dynlib-contract.t
@@ -1,0 +1,40 @@
+#!/usr/bin/perl
+
+# Static contract checks for the libcoraza dlopen boundary.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+use FindBin;
+
+###############################################################################
+
+my $root = "$FindBin::Bin/..";
+
+my $dl = slurp("$root/src/ngx_http_coraza_dl.c");
+
+unlike($dl, qr/DL_SYM\([^,]+,\s*coraza_rules_merge\)/,
+	'dead coraza_rules_merge symbol is not required at startup');
+
+unlike($dl, qr/DL_SYM\([^,]+,\s*coraza_add_get_args\)/,
+	'dead coraza_add_get_args symbol is not required at startup');
+
+unlike($dl, qr/\bfn_coraza_(?:rules_merge|add_get_args)\b/,
+	'dead Coraza function pointer typedefs are removed');
+
+unlike($dl, qr/\bdl_(?:rules_merge|add_get_args)\b/,
+	'dead Coraza function pointers are removed');
+
+done_testing();
+
+###############################################################################
+
+sub slurp {
+	my ($path) = @_;
+	open my $fh, '<', $path or die "open $path: $!";
+	local $/ = undef;
+	return <$fh>;
+}


### PR DESCRIPTION
Part of an 18-PR hardening series (numbered 01–18); each PR is independent against main, recommended review order is numeric.

**Severity:** Low

## What
Remove the `coraza_rules_merge` and `coraza_add_get_args` wrappers and their dlopen plumbing.

## Why
Neither symbol is called anywhere in the connector — they are dead weight in the dlopen table, and every extra required symbol is one more way for module load to fail against a differently-built libcoraza.

## Testing
Static contract test asserts the dlopen table only contains symbols the connector actually calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed support for two outdated Coraza integration symbols, simplifying dynamic loading and avoiding reliance on unavailable APIs.
* **Tests**
  * Added a contract test to verify the dynamic-loading boundary no longer references the removed symbols and related wrappers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->