### PR TITLE
fix: keep libcoraza loaded for worker lifetime

### DIFF
--- a/src/ngx_http_coraza_dl.c
+++ b/src/ngx_http_coraza_dl.c
@@ -166,18 +166,16 @@ ngx_http_coraza_dl_open(ngx_log_t *log)
 }
 
 /* ------------------------------------------------------------------ */
-/* Public: unload libcoraza.so                                         */
+/* Public: keep libcoraza.so loaded until the process exits            */
 /* ------------------------------------------------------------------ */
 
 void
 ngx_http_coraza_dl_close(ngx_log_t *log)
 {
     if (dl_handle != NULL) {
-        dynlib_close(dl_handle);
-        dl_handle = NULL;
-        ngx_log_error(NGX_LOG_NOTICE, log, 0,
-                      "coraza: %s unloaded",
-                      CORAZA_DYNLIB_BASENAME DYNLIB_EXT);
+        ngx_log_debug1(NGX_LOG_DEBUG_CORE, log, 0,
+                       "coraza: %s left loaded for process lifetime",
+                       CORAZA_DYNLIB_BASENAME DYNLIB_EXT);
     }
 }
 

--- a/t/coraza-dynlib-contract.t
+++ b/t/coraza-dynlib-contract.t
@@ -1,0 +1,39 @@
+#!/usr/bin/perl
+
+# Static contract checks for the libcoraza dlopen boundary.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+use FindBin;
+
+###############################################################################
+
+my $root = "$FindBin::Bin/..";
+
+my $dl = slurp("$root/src/ngx_http_coraza_dl.c");
+
+my ($close_body) = $dl =~
+	qr/ngx_http_coraza_dl_close\s*\([^)]*\)\s*\{(.*?)\n\}/s;
+
+ok(defined $close_body, 'found ngx_http_coraza_dl_close body');
+
+unlike($close_body, qr/\bdynlib_close\b/,
+	'worker exit does not unload the Go-backed libcoraza handle');
+
+unlike($close_body, qr/\bdl_handle\s*=\s*NULL\b/,
+	'worker exit keeps the loaded libcoraza handle intact');
+
+done_testing();
+
+###############################################################################
+
+sub slurp {
+	my ($path) = @_;
+	open my $fh, '<', $path or die "open $path: $!";
+	local $/ = undef;
+	return <$fh>;
+}


### PR DESCRIPTION
Part of an 18-PR hardening series (numbered 01–18); each PR is independent against main, recommended review order is numeric.

**Severity:** Medium

## What
Stop calling `dynlib_close()` on libcoraza; leave the library loaded for the process lifetime.

## Why
libcoraza embeds a Go runtime. A Go runtime cannot be safely unloaded via `dlclose()` — its signal handlers, GC threads and TLS blocks stay registered, so unloading the .so leaves dangling pointers and crashes on worker shutdown/reload paths. Keeping the handle for process lifetime is the documented-safe pattern for cgo libraries.

## Testing
Static contract test asserts the close path does not call `dynlib_close`.