### PR TITLE
fix: remove stale sanity check build traps

### DIFF
--- a/src/ddebug.h
+++ b/src/ddebug.h
@@ -25,15 +25,7 @@
  * #define CORAZA_DDEBUG 1
  */
 
-/*
- * Setting CORAZA_SANITY_CHECKS will help you in the debug process. By
- * defining CORAZA_SANITY_CHECKS a set of functions will be executed in
- * order to make sure the well behavior of CORAZA, letting you know (via
- * debug_logs) if something unexpected happens.
- *
- * If performance is not a concern, it is safe to keep it set.
- *
- */
+/* Kept as a no-op compatibility macro for old local debug builds. */
 #ifndef CORAZA_SANITY_CHECKS
 #define CORAZA_SANITY_CHECKS 0
 #endif

--- a/src/ngx_http_coraza_header_filter.c
+++ b/src/ngx_http_coraza_header_filter.c
@@ -115,10 +115,6 @@ ngx_http_coraza_resolv_header_date(ngx_http_request_t *r, ngx_str_t name, off_t 
         date.len = h->value.len;
     }
 
-#if defined(CORAZA_SANITY_CHECKS) && (CORAZA_SANITY_CHECKS)
-    ngx_http_coraza_store_ctx_header(r, &name, &date);
-#endif
-
     return coraza_add_response_header(ctx->coraza_transaction,
         (char *) name.data,
         name.len,
@@ -142,9 +138,6 @@ ngx_http_coraza_resolv_header_content_length(ngx_http_request_t *r, ngx_str_t na
         value.data = (unsigned char *)buf;
         value.len = strlen(buf);
 
-#if defined(CORAZA_SANITY_CHECKS) && (CORAZA_SANITY_CHECKS)
-        ngx_http_coraza_store_ctx_header(r, &name, &value);
-#endif
         return coraza_add_response_header(ctx->coraza_transaction,
             (char *) name.data,
             name.len,
@@ -165,10 +158,6 @@ ngx_http_coraza_resolv_header_content_type(ngx_http_request_t *r, ngx_str_t name
 
     if (r->headers_out.content_type.len > 0)
     {
-
-#if defined(CORAZA_SANITY_CHECKS) && (CORAZA_SANITY_CHECKS)
-        ngx_http_coraza_store_ctx_header(r, &name, &r->headers_out.content_type);
-#endif
 
         return coraza_add_response_header(ctx->coraza_transaction,
             (char *) name.data,
@@ -198,10 +187,6 @@ ngx_http_coraza_resolv_header_last_modified(ngx_http_request_t *r, ngx_str_t nam
 
     value.data = buf;
     value.len = (int)(p-buf);
-
-#if defined(CORAZA_SANITY_CHECKS) && (CORAZA_SANITY_CHECKS)
-    ngx_http_coraza_store_ctx_header(r, &name, &value);
-#endif
 
     return coraza_add_response_header(ctx->coraza_transaction,
         (char *) name.data,
@@ -235,10 +220,6 @@ ngx_http_coraza_resolv_header_connection(ngx_http_request_t *r, ngx_str_t name, 
             value.data = buf;
             value.len = strlen((char *)buf);
 
-#if defined(CORAZA_SANITY_CHECKS) && (CORAZA_SANITY_CHECKS)
-            ngx_http_coraza_store_ctx_header(r, &name2, &value);
-#endif
-
             coraza_add_response_header(ctx->coraza_transaction,
                 (char *) name2.data,
                 name2.len,
@@ -251,10 +232,6 @@ ngx_http_coraza_resolv_header_connection(ngx_http_request_t *r, ngx_str_t name, 
 
     value.data = (u_char *) connection;
     value.len = strlen(connection);
-
-#if defined(CORAZA_SANITY_CHECKS) && (CORAZA_SANITY_CHECKS)
-    ngx_http_coraza_store_ctx_header(r, &name, &value);
-#endif
 
     return coraza_add_response_header(ctx->coraza_transaction,
         (char *) name.data,
@@ -272,10 +249,6 @@ ngx_http_coraza_resolv_header_transfer_encoding(ngx_http_request_t *r, ngx_str_t
         ngx_str_t value = ngx_string("chunked");
 
         ctx = ngx_http_get_module_ctx(r, ngx_http_coraza_module);
-
-#if defined(CORAZA_SANITY_CHECKS) && (CORAZA_SANITY_CHECKS)
-        ngx_http_coraza_store_ctx_header(r, &name, &value);
-#endif
 
         return coraza_add_response_header(ctx->coraza_transaction,
             (char *) name.data,
@@ -299,10 +272,6 @@ ngx_http_coraza_resolv_header_vary(ngx_http_request_t *r, ngx_str_t name, off_t 
         ngx_str_t value = ngx_string("Accept-Encoding");
 
         ctx = ngx_http_get_module_ctx(r, ngx_http_coraza_module);
-
-#if defined(CORAZA_SANITY_CHECKS) && (CORAZA_SANITY_CHECKS)
-        ngx_http_coraza_store_ctx_header(r, &name, &value);
-#endif
 
         return coraza_add_response_header(ctx->coraza_transaction,
             (char *) name.data,
@@ -398,10 +367,6 @@ ngx_http_coraza_header_filter(ngx_http_request_t *r)
         if (data[i].hash == 0) {
             continue;
         }
-
-#if defined(CORAZA_SANITY_CHECKS) && (CORAZA_SANITY_CHECKS)
-        ngx_http_coraza_store_ctx_header(r, &data[i].key, &data[i].value);
-#endif
 
         /*
          * Doing this ugly cast here, explanation on the request_header

--- a/src/ngx_http_coraza_module.c
+++ b/src/ngx_http_coraza_module.c
@@ -518,10 +518,6 @@ ngx_http_coraza_merge_conf(ngx_conf_t *cf, void *parent, void *child)
 
 	ngx_conf_merge_value(c->enable, p->enable, 0);
 	ngx_conf_merge_ptr_value(c->transaction_id, p->transaction_id, NULL);
-#if defined(CORAZA_SANITY_CHECKS) && (CORAZA_SANITY_CHECKS)
-	ngx_conf_merge_value(c->sanity_checks_enabled, p->sanity_checks_enabled, 0);
-#endif
-
 	/*
 	 * Prepend parent rules to child rules — this produces the same rule
 	 * ordering as the old coraza_rules_merge() approach.

--- a/t/coraza-sanity-checks-compile.t
+++ b/t/coraza-sanity-checks-compile.t
@@ -57,7 +57,12 @@ sub compile_ok {
 		"$root/$source",
 	);
 
-	my $ok = system(@cmd) == 0;
+	# Redirect stderr to stdout and capture so a failing -Werror compile
+	# surfaces the actual diagnostics in CI instead of just pass/fail.
+	my $shell = join ' ', map { quotemeta } @cmd;
+	my $output = `$shell 2>&1`;
+	my $ok = $? == 0;
+	diag($output) unless $ok;
 	ok($ok, "$source compiles with CORAZA_SANITY_CHECKS=1");
 }
 

--- a/t/coraza-sanity-checks-compile.t
+++ b/t/coraza-sanity-checks-compile.t
@@ -1,0 +1,70 @@
+#!/usr/bin/perl
+
+# Compile regression for the CORAZA_SANITY_CHECKS debug macro.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+use FindBin;
+use File::Temp qw/tempdir/;
+
+###############################################################################
+
+my $root = "$FindBin::Bin/..";
+my $nginx = "$root/nginx-1.28.0";
+
+plan skip_all => 'cc not found' unless command_exists('cc');
+plan skip_all => 'nginx build tree not available'
+	unless -f "$nginx/objs/ngx_auto_config.h";
+plan skip_all => 'coraza headers not available'
+	unless -f '/usr/local/include/coraza/coraza.h';
+
+my $tmp = tempdir(CLEANUP => 1);
+my @includes = map { "-I$_" } (
+	'/usr/local/include',
+	"$nginx/src/core",
+	"$nginx/src/event",
+	"$nginx/src/event/modules",
+	"$nginx/src/event/quic",
+	"$nginx/src/os/unix",
+	"$nginx/objs",
+	"$nginx/src/http",
+	"$nginx/src/http/modules",
+	"$nginx/src/http/v2",
+);
+
+compile_ok('src/ngx_http_coraza_module.c', "$tmp/module.o");
+compile_ok('src/ngx_http_coraza_header_filter.c', "$tmp/header_filter.o");
+
+done_testing();
+
+###############################################################################
+
+sub compile_ok {
+	my ($source, $object) = @_;
+	my @cmd = (
+		'cc',
+		'-c',
+		'-fPIC',
+		'-Werror',
+		'-DCORAZA_SANITY_CHECKS=1',
+		@includes,
+		'-o',
+		$object,
+		"$root/$source",
+	);
+
+	my $ok = system(@cmd) == 0;
+	ok($ok, "$source compiles with CORAZA_SANITY_CHECKS=1");
+}
+
+sub command_exists {
+	my ($cmd) = @_;
+	for my $dir (split /:/, $ENV{PATH}) {
+		return 1 if -x "$dir/$cmd";
+	}
+	return 0;
+}


### PR DESCRIPTION
Part of an 18-PR hardening series (numbered 01–18); each PR is independent against main, recommended review order is numeric.

**Severity:** Low

## What
Remove the `CORAZA_SANITY_CHECKS` blocks (inherited from ModSecurity-nginx); keep the macro as a documented no-op for old debug builds.

## Why
The stored-header "sanity check" duplicates every response header into a per-request list that is never read by anything in the Coraza connector — it was only consumed by ModSecurity's debug tooling that never got ported. Compiling with the flag set silently costs memory per request and misleads readers into thinking the data is used.

## Testing
Module builds cleanly; full `t/` suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted response-header handling to remove unnecessary debug-only side effects from standard builds.
  * Updated configuration merging so the debug-related sanity-check flag is no longer carried over to child configurations.
* **Tests**
  * Added a regression test that verifies the debug macro remains accepted and the module sources still compile successfully during builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->