### PR TITLE
fix: omit NUL from synthetic server header

### DIFF
--- a/src/ngx_http_coraza_header_filter.c
+++ b/src/ngx_http_coraza_header_filter.c
@@ -78,10 +78,10 @@ ngx_http_coraza_resolv_header_server(ngx_http_request_t *r, ngx_str_t name, off_
     if (r->headers_out.server == NULL) {
         if (clcf->server_tokens) {
             value.data = (u_char *)ngx_http_server_full_string;
-            value.len = sizeof(ngx_http_server_full_string);
+            value.len = sizeof(ngx_http_server_full_string) - 1;
         } else {
             value.data = (u_char *)ngx_http_server_string;
-            value.len = sizeof(ngx_http_server_string);
+            value.len = sizeof(ngx_http_server_string) - 1;
         }
     } else {
         ngx_table_elt_t *h = r->headers_out.server;

--- a/t/coraza-response-server-header.t
+++ b/t/coraza-response-server-header.t
@@ -34,7 +34,7 @@ http {
     %%TEST_GLOBALS_HTTP%%
 
     server {
-        listen       127.0.0.1:8080;
+        listen       127.0.0.1:%%PORT_8080%%;
         server_name  localhost;
         server_tokens off;
 
@@ -56,15 +56,43 @@ http {
             ';
         }
     }
+
+    server {
+        listen       127.0.0.1:%%PORT_8081%%;
+        server_name  localhost;
+        server_tokens on;
+
+        coraza on;
+
+        # server_tokens on -> synthetic Server header uses the NGINX_VER
+        # fallback ("nginx/<version>"). Same NUL-truncation fix must apply.
+        location /server_ver_pass {
+            default_type text/plain;
+            coraza_rules '
+                SecRuleEngine On
+                SecRule RESPONSE_HEADERS:Server "!@beginsWith nginx/" "id:63,phase:3,deny,log,status:403"
+            ';
+        }
+
+        location /server_ver_block {
+            default_type text/plain;
+            coraza_rules '
+                SecRuleEngine On
+                SecRule RESPONSE_HEADERS:Server "@beginsWith nginx/" "id:64,phase:3,deny,log,status:403"
+            ';
+        }
+    }
 }
 EOF
 
 $t->write_file("/server_exact_pass", "server header must not include NUL");
 $t->write_file("/server_exact_block", "server header matched");
+$t->write_file("/server_ver_pass", "server header must not include NUL");
+$t->write_file("/server_ver_block", "server header matched");
 
 $t->run();
 $t->todo_alerts();
-$t->plan(2);
+$t->plan(4);
 
 ###############################################################################
 
@@ -73,3 +101,12 @@ like(http_get('/server_exact_pass'), qr/^HTTP.*200/,
 
 like(http_get('/server_exact_block'), qr/^HTTP.*403/,
 	'exact synthetic Server header can be matched');
+
+# server_tokens on lives on the second server (port 8081); target it explicitly.
+my $peer8081 = '127.0.0.1:' . port(8081);
+
+like(http_get('/server_ver_pass', PeerAddr => $peer8081), qr/^HTTP.*200/,
+	'synthetic Server header uses nginx/<ver> fallback with server_tokens on');
+
+like(http_get('/server_ver_block', PeerAddr => $peer8081), qr/^HTTP.*403/,
+	'nginx/<ver> synthetic Server header can be matched');

--- a/t/coraza-response-server-header.t
+++ b/t/coraza-response-server-header.t
@@ -1,0 +1,75 @@
+#!/usr/bin/perl
+
+# Tests for Coraza-nginx connector (synthetic Server response header).
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http/);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+        server_tokens off;
+
+        coraza on;
+
+        location /server_exact_pass {
+            default_type text/plain;
+            coraza_rules '
+                SecRuleEngine On
+                SecRule RESPONSE_HEADERS:Server "!@streq nginx" "id:61,phase:3,deny,log,status:403"
+            ';
+        }
+
+        location /server_exact_block {
+            default_type text/plain;
+            coraza_rules '
+                SecRuleEngine On
+                SecRule RESPONSE_HEADERS:Server "@streq nginx" "id:62,phase:3,deny,log,status:403"
+            ';
+        }
+    }
+}
+EOF
+
+$t->write_file("/server_exact_pass", "server header must not include NUL");
+$t->write_file("/server_exact_block", "server header matched");
+
+$t->run();
+$t->todo_alerts();
+$t->plan(2);
+
+###############################################################################
+
+like(http_get('/server_exact_pass'), qr/^HTTP.*200/,
+	'synthetic Server header is exactly nginx');
+
+like(http_get('/server_exact_block'), qr/^HTTP.*403/,
+	'exact synthetic Server header can be matched');


### PR DESCRIPTION
Part of an 18-PR hardening series (numbered 01–18); each PR is independent against main, recommended review order is numeric.

**Severity:** Medium

## What
Use `sizeof(...) - 1` for the synthesized `Server` header value length.

## Why
`sizeof` on a string literal includes the trailing NUL, so the connector was handing the WAF a `Server` value with an embedded `\0`. Rules matching on `RESPONSE_HEADERS:Server` see a corrupted value, and the stored header length no longer matches what nginx actually sends on the wire.

## Testing
Adds a regression test covering the synthetic Server header value seen by the WAF.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the reported length of the fallback `Server` header value so it no longer includes the trailing null byte.
  * This ensures the header is seen as the exact text expected by response inspection rules.

* **Tests**
  * Added coverage for response `Server` header handling, including successful matching and a blocked response when the header value matches a rule exactly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->