### PR TITLE
fix: propagate response header insert failures

### DIFF
--- a/src/ngx_http_coraza_header_filter.c
+++ b/src/ngx_http_coraza_header_filter.c
@@ -68,6 +68,12 @@ static ngx_int_t
 ngx_http_coraza_add_response_header(ngx_http_request_t *r,
     ngx_http_coraza_ctx_t *ctx, ngx_str_t *name, ngx_str_t *value)
 {
+    if (ctx == NULL) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+            "coraza: missing context while adding response header \"%V\"", name);
+        return NGX_ERROR;
+    }
+
     if (coraza_add_response_header(ctx->coraza_transaction,
         (char *) name->data,
         name->len,

--- a/src/ngx_http_coraza_header_filter.c
+++ b/src/ngx_http_coraza_header_filter.c
@@ -15,6 +15,8 @@
 
 static ngx_http_output_header_filter_pt ngx_http_next_header_filter;
 
+static ngx_int_t ngx_http_coraza_add_response_header(ngx_http_request_t *r,
+    ngx_http_coraza_ctx_t *ctx, ngx_str_t *name, ngx_str_t *value);
 static ngx_int_t ngx_http_coraza_resolv_header_server(ngx_http_request_t *r, ngx_str_t name, off_t offset);
 static ngx_int_t ngx_http_coraza_resolv_header_date(ngx_http_request_t *r, ngx_str_t name, off_t offset);
 static ngx_int_t ngx_http_coraza_resolv_header_content_length(ngx_http_request_t *r, ngx_str_t name, off_t offset);
@@ -63,6 +65,25 @@ ngx_http_coraza_header_out_t ngx_http_coraza_headers_out[] = {
 
 
 static ngx_int_t
+ngx_http_coraza_add_response_header(ngx_http_request_t *r,
+    ngx_http_coraza_ctx_t *ctx, ngx_str_t *name, ngx_str_t *value)
+{
+    if (coraza_add_response_header(ctx->coraza_transaction,
+        (char *) name->data,
+        name->len,
+        (char *) value->data,
+        value->len) < 0)
+    {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+            "coraza: failed to add response header \"%V\"", name);
+        return NGX_ERROR;
+    }
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
 ngx_http_coraza_resolv_header_server(ngx_http_request_t *r, ngx_str_t name, off_t offset)
 {
     static char ngx_http_server_full_string[] = NGINX_VER;
@@ -90,11 +111,7 @@ ngx_http_coraza_resolv_header_server(ngx_http_request_t *r, ngx_str_t name, off_
     }
 
 
-    return coraza_add_response_header(ctx->coraza_transaction,
-        (char *) name.data,
-        name.len,
-        (char *) value.data,
-        value.len);
+    return ngx_http_coraza_add_response_header(r, ctx, &name, &value);
 }
 
 
@@ -119,11 +136,7 @@ ngx_http_coraza_resolv_header_date(ngx_http_request_t *r, ngx_str_t name, off_t 
     ngx_http_coraza_store_ctx_header(r, &name, &date);
 #endif
 
-    return coraza_add_response_header(ctx->coraza_transaction,
-        (char *) name.data,
-        name.len,
-        (char *) date.data,
-        date.len);
+    return ngx_http_coraza_add_response_header(r, ctx, &name, &date);
 }
 
 
@@ -145,14 +158,10 @@ ngx_http_coraza_resolv_header_content_length(ngx_http_request_t *r, ngx_str_t na
 #if defined(CORAZA_SANITY_CHECKS) && (CORAZA_SANITY_CHECKS)
         ngx_http_coraza_store_ctx_header(r, &name, &value);
 #endif
-        return coraza_add_response_header(ctx->coraza_transaction,
-            (char *) name.data,
-            name.len,
-            (char *) value.data,
-            value.len);
+        return ngx_http_coraza_add_response_header(r, ctx, &name, &value);
     }
 
-    return 1;
+    return NGX_OK;
 }
 
 
@@ -170,14 +179,11 @@ ngx_http_coraza_resolv_header_content_type(ngx_http_request_t *r, ngx_str_t name
         ngx_http_coraza_store_ctx_header(r, &name, &r->headers_out.content_type);
 #endif
 
-        return coraza_add_response_header(ctx->coraza_transaction,
-            (char *) name.data,
-            name.len,
-            (char *) r->headers_out.content_type.data,
-            r->headers_out.content_type.len);
+        return ngx_http_coraza_add_response_header(r, ctx, &name,
+            &r->headers_out.content_type);
     }
 
-    return 1;
+    return NGX_OK;
 }
 
 
@@ -191,7 +197,7 @@ ngx_http_coraza_resolv_header_last_modified(ngx_http_request_t *r, ngx_str_t nam
     ctx = ngx_http_get_module_ctx(r, ngx_http_coraza_module);
 
     if (r->headers_out.last_modified_time == -1) {
-        return 1;
+        return NGX_OK;
     }
 
     p = ngx_http_time(buf, r->headers_out.last_modified_time);
@@ -203,11 +209,7 @@ ngx_http_coraza_resolv_header_last_modified(ngx_http_request_t *r, ngx_str_t nam
     ngx_http_coraza_store_ctx_header(r, &name, &value);
 #endif
 
-    return coraza_add_response_header(ctx->coraza_transaction,
-        (char *) name.data,
-        name.len,
-        (char *) value.data,
-        value.len);
+    return ngx_http_coraza_add_response_header(r, ctx, &name, &value);
 }
 
 
@@ -239,11 +241,11 @@ ngx_http_coraza_resolv_header_connection(ngx_http_request_t *r, ngx_str_t name, 
             ngx_http_coraza_store_ctx_header(r, &name2, &value);
 #endif
 
-            coraza_add_response_header(ctx->coraza_transaction,
-                (char *) name2.data,
-                name2.len,
-                (char *) value.data,
-                value.len);
+            if (ngx_http_coraza_add_response_header(r, ctx, &name2, &value)
+                != NGX_OK)
+            {
+                return NGX_ERROR;
+            }
         }
     } else {
         connection = "close";
@@ -256,11 +258,7 @@ ngx_http_coraza_resolv_header_connection(ngx_http_request_t *r, ngx_str_t name, 
     ngx_http_coraza_store_ctx_header(r, &name, &value);
 #endif
 
-    return coraza_add_response_header(ctx->coraza_transaction,
-        (char *) name.data,
-        name.len,
-        (char *) value.data,
-        value.len);
+    return ngx_http_coraza_add_response_header(r, ctx, &name, &value);
 }
 
 static ngx_int_t
@@ -277,14 +275,10 @@ ngx_http_coraza_resolv_header_transfer_encoding(ngx_http_request_t *r, ngx_str_t
         ngx_http_coraza_store_ctx_header(r, &name, &value);
 #endif
 
-        return coraza_add_response_header(ctx->coraza_transaction,
-            (char *) name.data,
-            name.len,
-            (char *) value.data,
-            value.len);
+        return ngx_http_coraza_add_response_header(r, ctx, &name, &value);
     }
 
-    return 1;
+    return NGX_OK;
 }
 
 static ngx_int_t
@@ -304,15 +298,11 @@ ngx_http_coraza_resolv_header_vary(ngx_http_request_t *r, ngx_str_t name, off_t 
         ngx_http_coraza_store_ctx_header(r, &name, &value);
 #endif
 
-        return coraza_add_response_header(ctx->coraza_transaction,
-            (char *) name.data,
-            name.len,
-            (char *) value.data,
-            value.len);
+        return ngx_http_coraza_add_response_header(r, ctx, &name, &value);
     }
 #endif
 
-    return 1;
+    return NGX_OK;
 }
 
 ngx_int_t
@@ -333,6 +323,7 @@ ngx_http_coraza_header_filter(ngx_http_request_t *r)
     ngx_table_elt_t *data = part->elts;
     ngx_uint_t i = 0;
     int ret = 0;
+    ngx_int_t rc;
     ngx_uint_t status;
     char *http_response_ver;
 
@@ -375,9 +366,12 @@ ngx_http_coraza_header_filter(ngx_http_request_t *r)
     for (i = 0; ngx_http_coraza_headers_out[i].name.len; i++)
     {
 
-                ngx_http_coraza_headers_out[i].resolver(r,
-                    ngx_http_coraza_headers_out[i].name,
-                    ngx_http_coraza_headers_out[i].offset);
+        rc = ngx_http_coraza_headers_out[i].resolver(r,
+            ngx_http_coraza_headers_out[i].name,
+            ngx_http_coraza_headers_out[i].offset);
+        if (rc != NGX_OK) {
+            return rc;
+        }
     }
 
     for (i = 0 ;; i++)
@@ -406,11 +400,11 @@ ngx_http_coraza_header_filter(ngx_http_request_t *r)
         /*
          * Doing this ugly cast here, explanation on the request_header
          */
-        coraza_add_response_header(ctx->coraza_transaction,
-            (char *) data[i].key.data,
-            data[i].key.len,
-            (char *) data[i].value.data,
-            data[i].value.len);
+        rc = ngx_http_coraza_add_response_header(r, ctx, &data[i].key,
+            &data[i].value);
+        if (rc != NGX_OK) {
+            return rc;
+        }
     }
 
     /* prepare extra paramters for msc_process_response_headers() */

--- a/t/coraza-header-error-propagation.t
+++ b/t/coraza-header-error-propagation.t
@@ -1,0 +1,47 @@
+#!/usr/bin/perl
+
+# Static regression checks for response-header insertion error handling.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+use FindBin;
+
+###############################################################################
+
+my $root = "$FindBin::Bin/..";
+my $src = slurp("$root/src/ngx_http_coraza_header_filter.c");
+
+my @raw_calls = $src =~ /\bcoraza_add_response_header\s*\(/g;
+is(scalar @raw_calls, 1,
+	'raw coraza_add_response_header call is confined to the checked helper');
+
+like($src,
+	qr/static ngx_int_t\s+ngx_http_coraza_add_response_header.*?<\s*0.*?return NGX_ERROR.*?return NGX_OK/s,
+	'checked helper maps Coraza header-add failures to NGX_ERROR');
+
+like($src,
+	qr/rc\s*=\s*ngx_http_coraza_headers_out\[i\]\.resolver\(.*?if\s*\(rc\s*!=\s*NGX_OK\)\s*\{\s*return rc;/s,
+	'built-in response-header resolver failures are propagated');
+
+like($src,
+	qr/rc\s*=\s*ngx_http_coraza_add_response_header\(r,\s*ctx,\s*&data\[i\]\.key,\s*&data\[i\]\.value\).*?if\s*\(rc\s*!=\s*NGX_OK\)\s*\{\s*return rc;/s,
+	'dynamic response-header list insertion failures are propagated');
+
+unlike($src,
+	qr/^\s*ngx_http_coraza_headers_out\[i\]\.resolver\(/m,
+	'resolver return values are not discarded');
+
+done_testing();
+
+###############################################################################
+
+sub slurp {
+	my ($path) = @_;
+	open my $fh, '<', $path or die "open $path: $!";
+	local $/ = undef;
+	return <$fh>;
+}


### PR DESCRIPTION
Part of an 18-PR hardening series (numbered 01–18); each PR is independent against main, recommended review order is numeric.

**Severity:** Medium

## What
Route every response-header insertion into the WAF through one checked helper, `ngx_http_coraza_add_response_header()`, and propagate failures.

## Why
`coraza_add_response_header()` can fail (cgo boundary), but the call sites ignored the return value — on failure the WAF silently evaluates phase 3/4 rules against an incomplete header set, i.e. a fail-open. Now any insert failure is logged and aborts the filter with `NGX_ERROR`.

## Testing
Adds `t/coraza-header-error-propagation.t` (static contract: all inserts confined to the checked helper, failures propagated).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated response-header insertion so failures are detected and handled immediately rather than silently ignored.
  - Standardized header resolver outcomes to consistently return success or failure, improving error reporting across common headers.

- **Tests**
  - Added a regression test that validates error propagation behavior for response-header handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->