### PR TITLE
fix: return empty C string for empty ngx_str

### DIFF
--- a/src/ngx_http_coraza_utils.c
+++ b/src/ngx_http_coraza_utils.c
@@ -18,19 +18,15 @@
 ngx_int_t
 ngx_str_to_char(ngx_str_t a, char **str, ngx_pool_t *p)
 {
-    if (a.len == 0)
-    {
-        *str = NULL;
-        return NGX_OK;
-    }
-
     *str = ngx_pnalloc(p, a.len + 1);
     if (*str == NULL)
     {
         dd("failed to allocate memory to convert ngx_string to C string");
         return NGX_ERROR;
     }
-    ngx_memcpy(*str, a.data, a.len);
+    if (a.len > 0) {
+        ngx_memcpy(*str, a.data, a.len);
+    }
     (*str)[a.len] = '\0';
 
     return NGX_OK;


### PR DESCRIPTION
Part of an 18-PR hardening series (numbered 01–18); each PR is independent against main, recommended review order is numeric.

**Severity:** Medium

## What
Make `ngx_str_to_char()` return an empty NUL-terminated string for a zero-length `ngx_str_t` instead of `NULL`.

## Why
Several callers pass the result straight into libcoraza without a NULL check. An empty header value or empty URI part therefore turned into a NULL pointer at the cgo boundary — at best the value is silently dropped from rule evaluation, at worst it is dereferenced. An empty C string preserves the actual semantics ("present but empty").

## Testing
Covered by the `fuzz/fuzz_str_to_char.c` libFuzzer target (series PR 01) and the existing `t/` suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved string handling for empty values by always creating a valid NUL-terminated C string buffer.
  * Prevents failures from inconsistent empty-string behavior and makes allocation errors explicit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->