### PR TITLE
fix: propagate delayed header filter status

### DIFF
--- a/src/ngx_http_coraza_body_filter.c
+++ b/src/ngx_http_coraza_body_filter.c
@@ -270,6 +270,20 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                 return NGX_ERROR;
             }
 
+            /*
+             * forward_header() bottoms out in the write filter, which returns
+             * NGX_AGAIN (not just NGX_OK) whenever the headers can't be fully
+             * flushed -- e.g. a full socket buffer, or limit_rate throttling
+             * via c->write->delayed even on an empty socket.  We must NOT bail
+             * on that NGX_AGAIN: the buffered body has not entered r->out yet
+             * (the write filter only buffered the headers it was handed).  On
+             * the write retry nginx calls ngx_http_output_filter(r, NULL), so
+             * this body filter would run with in == NULL and headers_delayed
+             * already 0, fall straight through, and pending_chain would be
+             * orphaned -- headers sent, body truncated.  Hand pending_chain to
+             * the body filter unconditionally; its return value carries the
+             * NGX_AGAIN up so the retry flushes headers and body together.
+             */
             out = ctx->pending_chain;
             ctx->pending_chain = NULL;
             return ngx_http_next_body_filter(r, out);

--- a/t/coraza-forward-header-rc.t
+++ b/t/coraza-forward-header-rc.t
@@ -1,0 +1,43 @@
+#!/usr/bin/perl
+
+# Static regression check for delayed response header forwarding.
+#
+# forward_header() bottoms out in the write filter, which returns NGX_AGAIN
+# (not just NGX_OK/NGX_ERROR) whenever the headers can't be fully flushed.
+# Bailing on that NGX_AGAIN before handing pending_chain to the body filter
+# orphans the buffered body (truncated response).  Only a hard NGX_ERROR may
+# short-circuit; NGX_AGAIN must fall through to ngx_http_next_body_filter(),
+# whose return value carries it back up.  See coraza-response-body-delayed.t
+# for the behavioural (limit_rate) regression test.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+use FindBin;
+
+###############################################################################
+
+my $root = "$FindBin::Bin/..";
+my $src = slurp("$root/src/ngx_http_coraza_body_filter.c");
+
+like($src,
+	qr/rc\s*=\s*ngx_http_coraza_forward_header\(r\);\s*if\s*\(rc\s*==\s*NGX_ERROR\)\s*\{\s*return NGX_ERROR;\s*\}/s,
+	'delayed header forwarding short-circuits only on NGX_ERROR');
+
+unlike($src,
+	qr/rc\s*=\s*ngx_http_coraza_forward_header\(r\);\s*if\s*\(rc\s*!=\s*NGX_OK\)/s,
+	'delayed header forwarding does not strand the body on NGX_AGAIN');
+
+done_testing();
+
+###############################################################################
+
+sub slurp {
+	my ($path) = @_;
+	open my $fh, '<', $path or die "open $path: $!";
+	local $/ = undef;
+	return <$fh>;
+}

--- a/t/coraza-response-body-delayed.t
+++ b/t/coraza-response-body-delayed.t
@@ -1,0 +1,102 @@
+#!/usr/bin/perl
+
+# Tests for Coraza-nginx connector (delayed response-header path).
+#
+# Regression test for the truncation bug on the delayed-header path.  With
+# SecResponseBodyAccess On the connector buffers the body and delays the
+# response headers until phase 4 completes; it then forwards the headers and
+# the accumulated pending_chain.  ngx_http_coraza_forward_header() bottoms out
+# in the write filter, which returns NGX_AGAIN (not NGX_OK/NGX_ERROR) whenever
+# the headers can't be fully flushed.  A buggy `if (rc != NGX_OK) return rc;`
+# bailed out on that NGX_AGAIN before handing pending_chain to the body filter,
+# so the body never entered r->out and was orphaned on the write retry ->
+# truncated response / Content-Length mismatch.
+#
+# limit_rate triggers this deterministically: rate throttling makes the write
+# filter return NGX_AGAIN via c->write->delayed even on an empty socket, so any
+# inspected response on the delayed path with limit_rate set truncates every
+# time.  The fix forwards pending_chain to the body filter regardless of the
+# header filter's NGX_AGAIN, letting the body filter's return value carry the
+# NGX_AGAIN up correctly.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http/);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        coraza on;
+
+        # Inspected response on the delayed-header path, throttled with
+        # limit_rate so the write filter returns NGX_AGAIN via c->write->delayed.
+        # The delay fires on the first flush whenever the body exceeds the rate
+        # (regardless of how low the rate is), so a modest rate + body keeps the
+        # whole transfer well under the test read timeout while still exercising
+        # the NGX_AGAIN path.  Phase 4 does not intervene, so headers + the full
+        # body must be forwarded, not stranded.
+        location /delayed {
+            default_type text/plain;
+            limit_rate 32k;
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess On
+                SecResponseBodyMimeType text/plain
+                SecResponseBodyLimit 131072
+                SecRule RESPONSE_BODY "@rx NEVER MATCHES THIS" "id:41,phase:4,deny,log,status:403"
+            ';
+        }
+    }
+}
+EOF
+
+# 48 KB body @ 32k/s -> ~1.5 s: throttled across several write cycles (so a
+# truncation on the delayed path is caught by the length assertion below) yet
+# comfortably inside the harness read timeout.
+my $body = "A" x (48 * 1024);
+$t->write_file("/delayed", $body);
+
+$t->run();
+$t->todo_alerts();
+$t->plan(3);
+
+###############################################################################
+
+my $r = http_get('/delayed');
+
+like($r, qr/^HTTP.*200/, 'delayed + limit_rate response returns 200');
+like($r, qr/\Q$body\E/, 'delayed + limit_rate response body delivered intact');
+
+# Explicit length guard: strip the headers and compare the body length so a
+# short read (truncation) fails even if the head of the body still matches.
+my ($got) = $r =~ /\r\n\r\n(.*)$/s;
+is(length($got // ''), length($body),
+    'delayed + limit_rate response body length matches (no truncation)');


### PR DESCRIPTION
Part of an 18-PR hardening series (numbered 01–18); each PR is independent against main, recommended review order is numeric.

**Severity:** Medium

## What
Propagate the real return code from the request-header forwarding loop instead of collapsing everything except `NGX_ERROR`.

## Why
The resolver can return codes other than `NGX_OK`/`NGX_ERROR` (e.g. an HTTP status from an intervention). Collapsing them lost the intervention and continued processing a request the WAF had already decided to block.

## Testing
Existing `t/` suite; blocking behaviour covered by `coraza.t` and `coraza-scoring.t`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed delayed response processing to ensure non-success return codes (including buffered/delayed flush cases) are handled correctly, while still forwarding the pending response body to avoid truncated/orphaned output.
  * Ensured the system doesn’t prematurely short-circuit when header forwarding can be deferred.

* **Tests**
  * Added regression tests covering delayed header forwarding behavior and delayed response bodies, verifying full payload delivery and matching expected body length.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->