### PR TITLE
fix: remove linker path from include flags

### DIFF
--- a/config
+++ b/config
@@ -36,7 +36,6 @@ if test -n "$ngx_module_link"; then
 
 	ngx_module_deps="$ngx_addon_dir/src/ddebug.h";
     ngx_module_libs="-ldl"
-    ngx_module_incs="-L/usr/local/lib"
 
     ngx_module_order="ngx_http_chunked_filter_module \
                       ngx_http_v2_filter_module \

--- a/t/coraza-config-flags.t
+++ b/t/coraza-config-flags.t
@@ -1,0 +1,33 @@
+#!/usr/bin/perl
+
+# Static regression checks for nginx addon config flags.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+use FindBin;
+
+###############################################################################
+
+my $root = "$FindBin::Bin/..";
+my $config = slurp("$root/config");
+
+unlike($config, qr/ngx_module_incs=.*-L/,
+	'linker search paths are not placed in ngx_module_incs');
+
+like($config, qr/ngx_module_libs="-ldl"/,
+	'dynamic module links against libdl');
+
+done_testing();
+
+###############################################################################
+
+sub slurp {
+	my ($path) = @_;
+	open my $fh, '<', $path or die "open $path: $!";
+	local $/ = undef;
+	return <$fh>;
+}


### PR DESCRIPTION
Part of an 18-PR hardening series (numbered 01–18); each PR is independent against main, recommended review order is numeric.

**Severity:** Low

## What
Drop the hardcoded `-L/usr/local/lib` from `config`.

## Why
The connector dlopens libcoraza at runtime — nothing links against it at build time, so the flag is dead. Worse, it silently steers the linker of anything else in the build toward `/usr/local/lib` ahead of the system paths, which breaks reproducible/pbuilder builds.

## Testing
Module configures and builds without the flag; full `t/` suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated build configuration so module include/link settings no longer inject linker-style `-L` search paths.
  * Kept existing dynamic linking and module build ordering unchanged (including `-ldl`).

* **Tests**
  * Added a regression test that statically checks the top-level `config` file to confirm `ngx_module_incs` excludes `-L` entries and `ngx_module_libs` includes `-ldl`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->