### PR TITLE
fix: cap delayed response-body buffering to bound worker memory

### DIFF
--- a/src/ngx_http_coraza_body_filter.c
+++ b/src/ngx_http_coraza_body_filter.c
@@ -142,6 +142,13 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                 }
                 return ngx_http_filter_finalize_request(r,
                     &ngx_http_coraza_module, ret);
+            } else if (ret < 0) {
+                ctx->intervention_triggered = 1;
+                if (ctx->headers_delayed) {
+                    ctx->headers_delayed = 0;
+                    return NGX_HTTP_INTERNAL_SERVER_ERROR;
+                }
+                return NGX_ERROR;
             }
         }
 
@@ -232,6 +239,8 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                     b->memory = 1;
                 }
 
+                ctx->pending_bytes += len;
+
                 b->last_buf      = 0;
                 b->last_in_chain = chain->buf->last_in_chain;
                 b->flush         = chain->buf->flush;
@@ -275,7 +284,43 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
             return ngx_http_next_body_filter(r, out);
         }
 
-        /* Not the last buffer yet -- all chunks were accumulated above. */
+        /*
+         * Not the last buffer yet.  If we have buffered more than the cap,
+         * stop delaying: flush the delayed headers plus everything accumulated
+         * so far and let the remainder stream through.  This bounds worker
+         * memory on large or open-ended (streaming, e.g. SSE / long-poll)
+         * responses, whose delayed-header buffering would otherwise grow
+         * without limit in r->pool waiting for a last_buf that may never come.
+         *
+         * Trade-off: once the headers are on the wire a phase-4 rule can no
+         * longer produce a clean error page for this (oversized) response — an
+         * intervention past this point degrades to a connection reset.  We
+         * accept that to prevent an OOM/DoS on unbounded responses.
+         */
+        if (ctx->pending_bytes > NGX_HTTP_CORAZA_MAX_DELAYED_BODY) {
+            ngx_int_t    rc;
+            ngx_chain_t *out;
+
+            ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
+                "coraza: delayed response body exceeded %uz bytes; flushing "
+                "headers early, phase-4 body blocking is no longer clean for "
+                "this response",
+                (size_t) NGX_HTTP_CORAZA_MAX_DELAYED_BODY);
+
+            ctx->headers_delayed = 0;
+
+            rc = ngx_http_coraza_forward_header(r);
+            if (rc != NGX_OK) {
+                return rc;
+            }
+
+            out = ctx->pending_chain;
+            ctx->pending_chain = NULL;
+            ctx->pending_chain_last = &ctx->pending_chain;
+            return ngx_http_next_body_filter(r, out);
+        }
+
+        /* Under the cap -- keep accumulating until last_buf. */
         return NGX_OK;
     }
 

--- a/src/ngx_http_coraza_body_filter.c
+++ b/src/ngx_http_coraza_body_filter.c
@@ -148,7 +148,8 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                     ctx->headers_delayed = 0;
                     return NGX_HTTP_INTERNAL_SERVER_ERROR;
                 }
-                return NGX_ERROR;
+                return ngx_http_filter_finalize_request(r,
+                    &ngx_http_coraza_module, NGX_HTTP_INTERNAL_SERVER_ERROR);
             }
         }
 

--- a/src/ngx_http_coraza_common.h
+++ b/src/ngx_http_coraza_common.h
@@ -77,6 +77,7 @@ typedef struct {
 
     ngx_chain_t *pending_chain;
     ngx_chain_t **pending_chain_last;
+    size_t       pending_bytes;   /* bytes buffered while headers are delayed */
 
     unsigned waiting_more_body:1;
     unsigned body_requested:1;
@@ -118,6 +119,21 @@ typedef struct {
     ngx_uint_t offset;
     ngx_http_coraza_resolv_header_pt resolver;
 } ngx_http_coraza_header_out_t;
+
+
+/*
+ * Upper bound on how many response-body bytes the connector will buffer in the
+ * request pool while it delays response headers for phase-4 inspection.  Once
+ * the accumulated body passes this cap the delayed headers and everything
+ * buffered so far are flushed and the remainder streams through, so a large or
+ * open-ended (streaming) response cannot grow worker memory without limit.
+ * Coraza's own SecResponseBodyLimit governs how much it actually inspects; this
+ * only bounds the connector's delayed-header buffering.  Override at build time
+ * with -DNGX_HTTP_CORAZA_MAX_DELAYED_BODY=<bytes>.
+ */
+#ifndef NGX_HTTP_CORAZA_MAX_DELAYED_BODY
+#define NGX_HTTP_CORAZA_MAX_DELAYED_BODY (1024 * 1024)
+#endif
 
 
 extern ngx_module_t ngx_http_coraza_module;

--- a/t/coraza-response-body-cap-intervention.t
+++ b/t/coraza-response-body-cap-intervention.t
@@ -1,0 +1,81 @@
+#!/usr/bin/perl
+
+# Tests for Coraza-nginx connector (post-cap response body interventions).
+#
+# Once the delayed response-body cap is exceeded, the connector flushes headers
+# early.  Any later disruptive response-body intervention cannot send a clean
+# error page anymore, but it must still stop streaming the response promptly.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http/);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    error_log %%TESTDIR%%/cap-intervention.log warn;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location /late-limit {
+            default_type text/plain;
+            coraza on;
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess On
+                SecResponseBodyMimeType text/plain
+                SecResponseBodyLimit 1572864
+                SecResponseBodyLimitAction Reject
+            ';
+        }
+    }
+}
+EOF
+
+my $size = 4 * 1024 * 1024;
+$t->write_file('/late-limit', 'L' x $size);
+
+$t->run();
+$t->todo_alerts();
+$t->plan(4);
+
+###############################################################################
+
+my $r = http_get('/late-limit');
+like($r, qr/^HTTP\S+ 200/, 'oversized response starts before late intervention');
+
+my ($body) = $r =~ /\r\n\r\n(.*)$/s;
+ok(length($body // '') < 2_500_000,
+    'post-flush intervention stops the response near the Coraza limit');
+isnt(length($body // ''), $size,
+    'post-flush intervention does not stream the complete response');
+
+$t->stop();
+like($t->read_file('cap-intervention.log'), qr/flushing headers early/,
+    'connector flushed delayed headers before the intervention');

--- a/t/coraza-response-body-cap.t
+++ b/t/coraza-response-body-cap.t
@@ -1,0 +1,89 @@
+#!/usr/bin/perl
+
+# Tests for Coraza-nginx connector (delayed-response buffering cap).
+#
+# The header filter delays response headers until phase 4 completes so a
+# phase-4 rule can still return a clean error page.  While delayed, the body
+# filter accumulates every response buffer into the request pool.  For a large
+# or open-ended (streaming) response that buffering would grow without limit
+# and OOM the worker.
+#
+# The fix caps the accumulation at NGX_HTTP_CORAZA_MAX_DELAYED_BODY (1 MiB by
+# default): once exceeded, the delayed headers + everything buffered so far are
+# flushed and the remainder streams through.  This test drives a response well
+# past the cap (with SecResponseBodyAccess Off, so the body is still delayed
+# and buffered but Coraza itself does not inspect/limit it) and asserts:
+#   1. the response still completes with 200 and an intact body, and
+#   2. the connector logged that it flushed early (the cap path executed).
+# See src/ngx_http_coraza_body_filter.c (NGX_HTTP_CORAZA_MAX_DELAYED_BODY).
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http/);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    error_log %%TESTDIR%%/cap.log warn;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        coraza on;
+
+        location /big {
+            default_type application/octet-stream;
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess Off
+            ';
+        }
+    }
+}
+EOF
+
+# 4 MiB response — comfortably past the 1 MiB default cap, delivered in many
+# buffers so pending_bytes crosses the cap before last_buf arrives.
+my $size = 4 * 1024 * 1024;
+$t->write_file("/big", "Z" x $size);
+
+$t->run();
+$t->todo_alerts();
+$t->plan(3);
+
+###############################################################################
+
+my $r = http_get('/big');
+like($r, qr/^HTTP.*200/, 'oversized delayed response still returns 200');
+
+my ($body) = $r =~ /\r\n\r\n(.*)$/s;
+is(length($body // ''), $size, 'oversized response body delivered intact');
+
+$t->stop();
+like($t->read_file('cap.log'), qr/flushing headers early/,
+    'connector flushed delayed headers once the buffering cap was exceeded');


### PR DESCRIPTION
Part of an 18-PR hardening series (numbered 01–18); each PR is independent against main, recommended review order is numeric.

**Severity:** High

## What
Track the byte count buffered for the delayed-headers feature and, once it exceeds `NGX_HTTP_CORAZA_MAX_DELAYED_BODY` (1 MiB default, build-time overridable), stop delaying: flush the delayed headers plus everything accumulated so far and let the remainder stream through.

Additionally, handle a late (post-flush) disruptive body intervention: `ngx_http_coraza_process_intervention()` returns `NGX_ERROR` once `r->header_sent` is set, and the body filter previously fell through on that error and kept streaming the denied response. The negative return is now handled explicitly — streaming stops (`NGX_ERROR`) so the intervention still terminates the transfer promptly.

## Why
While the header filter delays response headers for phase-4 inspection, the body filter accumulates every response buffer into the request pool (`pending_chain`). For a large download, or an open-ended streaming response (SSE / long-poll) that never emits `last_buf`, that buffering grows without limit and can OOM/DoS the worker. `SecResponseBodyLimit` does not help — the connector buffers for the delayed-headers feature independently of Coraza's own inspection.

Trade-off: past the cap a phase-4 rule can no longer return a clean error page for that response (an intervention degrades to a stopped transfer) — an acceptable price to avoid unbounded memory growth on oversized/streaming responses. The post-flush intervention handling above keeps that degradation prompt and fail-closed instead of streaming the rest of a denied response.

## Testing
`t/coraza-response-body-cap.t` drives a 4 MiB delayed response and asserts it completes with 200 + intact body and that the cap path logged the early flush. `t/coraza-response-body-cap-intervention.t` adds a late (post-flush) `SecResponseBodyLimit Reject` intervention and asserts the response starts (200, headers flushed early) but stops near the Coraza limit instead of streaming the full body.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable limit on how much response body can be buffered while delaying headers, with a default cap of 1 MiB.

* **Bug Fixes**
  * Improved handling of intervention errors during ongoing response processing so failures surface immediately and consistently.
  * Enhanced delayed-response buffering accounting and enforce the delayed-body cap by flushing delayed headers early and stopping further buffering once exceeded.

* **Tests**
  * Added integration tests covering delayed-body cap behavior and ensuring late post-body-cap interventions are handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->