### PR TITLE
perf: make response body header delay configurable

### DIFF
--- a/src/ngx_http_coraza_common.h
+++ b/src/ngx_http_coraza_common.h
@@ -106,6 +106,7 @@ typedef struct {
 
     ngx_flag_t                 enable;
     ngx_flag_t                 has_rules;
+    ngx_flag_t                 delay_response_headers;
 
     ngx_http_complex_value_t  *transaction_id;
 } ngx_http_coraza_conf_t;

--- a/src/ngx_http_coraza_header_filter.c
+++ b/src/ngx_http_coraza_header_filter.c
@@ -335,6 +335,7 @@ ngx_http_coraza_header_filter(ngx_http_request_t *r)
     int ret = 0;
     ngx_uint_t status;
     char *http_response_ver;
+    ngx_http_coraza_conf_t *mcf;
 
 
     /* 304 Not Modified responses are still processed for header inspection
@@ -347,6 +348,8 @@ ngx_http_coraza_header_filter(ngx_http_request_t *r)
     {
         return ngx_http_next_header_filter(r);
     }
+
+    mcf = ngx_http_get_module_loc_conf(r, ngx_http_coraza_module);
 
     if (ctx->intervention_triggered) {
         return ngx_http_next_header_filter(r);
@@ -506,8 +509,12 @@ ngx_http_coraza_header_filter(ngx_http_request_t *r)
      * page because the original 200 headers have not yet been sent to the
      * client.
      *
-     * We skip the delay for HEAD requests (no body to inspect), error pages
-     * (already an error response), and subrequests (handled independently).
+     * We skip the delay when coraza_delay_response_headers is off (operators who
+     * know their loaded ruleset has no phase-4 response rules can restore
+     * normal header streaming and accept that late phase-4 interventions can
+     * no longer produce a clean error page after headers are sent), for HEAD
+     * requests (no body to inspect), error pages (already an error response),
+     * and subrequests (handled independently).
      * We also skip the delay when body inspection is not needed
      * (SecResponseBodyAccess Off or Content-Type mismatch): in that case
      * there is no phase-4 buffering and the response must not be held back.
@@ -518,7 +525,8 @@ ngx_http_coraza_header_filter(ngx_http_request_t *r)
      * Delaying the 101 would hold the handshake forever and the upgrade
      * would never complete.
      */
-    if (!r->header_only && !r->error_page && r == r->main
+    if (mcf->delay_response_headers
+        && !r->header_only && !r->error_page && r == r->main
         && r->headers_out.status != NGX_HTTP_SWITCHING_PROTOCOLS)
     {
         /*

--- a/src/ngx_http_coraza_module.c
+++ b/src/ngx_http_coraza_module.c
@@ -306,6 +306,12 @@ static ngx_command_t ngx_http_coraza_commands[] = {
 	 NGX_HTTP_LOC_CONF_OFFSET,
 	 0,
 	 NULL},
+	{ngx_string("coraza_delay_response_headers"),
+	 NGX_HTTP_LOC_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_MAIN_CONF | NGX_CONF_FLAG,
+	 ngx_conf_set_flag_slot,
+	 NGX_HTTP_LOC_CONF_OFFSET,
+	 offsetof(ngx_http_coraza_conf_t, delay_response_headers),
+	 NULL},
 	ngx_null_command};
 
 static ngx_http_module_t ngx_http_coraza_ctx = {
@@ -478,9 +484,11 @@ ngx_http_coraza_create_conf(ngx_conf_t *cf)
 	 *     conf->pool = NULL;
 	 *     conf->transaction_id = NULL;
 	 *     conf->has_rules = 0;
+	 *     conf->delay_response_headers = 0;
 	 */
 
 	conf->enable = NGX_CONF_UNSET;
+	conf->delay_response_headers = NGX_CONF_UNSET;
 	conf->waf = 0;
 	conf->pool = cf->pool;
 	conf->transaction_id = NGX_CONF_UNSET_PTR;
@@ -517,6 +525,8 @@ ngx_http_coraza_merge_conf(ngx_conf_t *cf, void *parent, void *child)
 	   (int)c->enable, (int)p->enable);
 
 	ngx_conf_merge_value(c->enable, p->enable, 0);
+	ngx_conf_merge_value(c->delay_response_headers,
+						 p->delay_response_headers, 1);
 	ngx_conf_merge_ptr_value(c->transaction_id, p->transaction_id, NULL);
 #if defined(CORAZA_SANITY_CHECKS) && (CORAZA_SANITY_CHECKS)
 	ngx_conf_merge_value(c->sanity_checks_enabled, p->sanity_checks_enabled, 0);

--- a/t/coraza-delay-response-headers.t
+++ b/t/coraza-delay-response-headers.t
@@ -1,0 +1,280 @@
+#!/usr/bin/perl
+
+# Tests for Coraza-nginx connector (configurable response-header delay).
+#
+# By default the connector delays response headers until phase 4 completes so a
+# response-body or late non-body phase-4 intervention can still return a clean
+# error page.  coraza_delay_response_headers off lets operators with no phase-4
+# response rules opt out and stream headers immediately.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+use IO::Socket::INET;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(8);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:%%PORT_8080%%;
+        server_name  localhost;
+        postpone_output 1;
+
+        location /delay-off {
+            coraza on;
+            coraza_delay_response_headers off;
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess Off
+            ';
+            proxy_buffering off;
+            proxy_pass http://127.0.0.1:%%PORT_8081%%;
+        }
+
+        location /delay-default {
+            coraza on;
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess Off
+            ';
+            proxy_buffering off;
+            proxy_pass http://127.0.0.1:%%PORT_8081%%;
+        }
+
+        location /delay-on {
+            coraza on;
+            coraza_delay_response_headers on;
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess Off
+            ';
+            proxy_buffering off;
+            proxy_pass http://127.0.0.1:%%PORT_8081%%;
+        }
+
+        location /block-default {
+            default_type text/plain;
+            coraza on;
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess Off
+                SecRule ARGS "@streq block" "id:151,phase:4,deny,log,status:403"
+            ';
+        }
+
+        location /block-on {
+            default_type text/plain;
+            coraza on;
+            coraza_delay_response_headers on;
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess Off
+                SecRule ARGS "@streq block" "id:152,phase:4,deny,log,status:403"
+            ';
+        }
+    }
+}
+EOF
+
+$t->write_file('/block-default', 'ORIGINAL-BODY');
+$t->write_file('/block-on', 'ORIGINAL-BODY');
+my $testdir = $t->testdir();
+
+$t->run_daemon(\&delayed_daemon);
+$t->run()->waitforsocket('127.0.0.1:' . port(8081));
+$t->todo_alerts();
+
+###############################################################################
+
+my ($early, $full) = timed_get('/delay-off');
+like($early, qr/^HTTP\S+ 200.*X-Delayed-Upstream: yes/s,
+    'delay off forwards response headers before upstream body');
+unlike($early, qr/DELAYED-BODY/,
+    'delay off early read contains headers but not the delayed body');
+like($full, qr/DELAYED-BODY/, 'delay off still forwards the body');
+
+($early, $full) = timed_get('/delay-default');
+is($early, '', 'default response-body delay withholds headers until body');
+like($full, qr/^HTTP\S+ 200.*DELAYED-BODY/s,
+    'default response-body delay eventually forwards response');
+
+($early, $full) = timed_get('/delay-on');
+is($early, '', 'explicit response-body delay on withholds headers until body');
+
+like(http_get('/block-default?q=block'), qr/^HTTP\S+ 403/,
+    'default delay preserves clean phase-4 non-body block');
+
+like(http_get('/block-on?q=block'), qr/^HTTP\S+ 403/,
+    'explicit delay on preserves clean phase-4 non-body block');
+
+###############################################################################
+
+sub timed_get {
+    my ($uri) = @_;
+
+    my $s = IO::Socket::INET->new(
+        Proto => 'tcp',
+        PeerAddr => '127.0.0.1:' . port(8080),
+    ) or die "Can't connect to nginx: $!\n";
+    $s->autoflush(1);
+
+    print $s "GET $uri HTTP/1.1\r\n"
+        . "Host: localhost\r\n"
+        . "Connection: close\r\n\r\n";
+
+    # Deterministic sync: the daemon writes the "headers-" marker right after it
+    # has sent the response headers upstream, then blocks on the "release-"
+    # marker before sending the body.  So between wait_for_upstream_headers()
+    # returning and release_body() being called, nginx has upstream headers but
+    # no body -- whatever the client has received in that window is purely the
+    # forwarded-header state, with no wall-clock guessing.
+    wait_for_upstream_headers($uri);
+
+    # Drain everything the client can see WHILE the body is still withheld.
+    # Loop until the socket goes idle (no bytes for a full poll interval) so a
+    # slow header-forward under CI load still lands in $early; the body cannot
+    # race in because the daemon is blocked on the release marker.
+    my $early = drain_pending($s);
+
+    release_body($uri);
+
+    my $full = $early;
+    local $SIG{ALRM} = sub { die "timeout\n" };
+    eval {
+        alarm(5);
+        while (sysread($s, my $chunk, 4096)) {
+            $full .= $chunk;
+        }
+        alarm(0);
+    };
+    alarm(0);
+    close $s;
+
+    return ($early, $full);
+}
+
+sub drain_pending {
+    my ($s) = @_;
+
+    my $data = '';
+    my $rin = '';
+    vec($rin, fileno($s), 1) = 1;
+
+    # Read until the socket is idle for a full interval.  While the daemon holds
+    # the body back (release marker not yet written) an idle socket means "all
+    # currently-forwarded bytes captured", not "body might still arrive".
+    while (select(my $rout = $rin, undef, undef, 0.3) > 0) {
+        my $n = sysread($s, my $chunk, 4096);
+        last if !$n;            # peer closed / error
+        $data .= $chunk;
+    }
+
+    return $data;
+}
+
+sub release_body {
+    my ($uri) = @_;
+
+    open my $fh, '>', "$testdir/release-" . marker_key($uri)
+        or die "Can't write release marker: $!\n";
+    print $fh "go\n";
+    close $fh;
+}
+
+sub wait_for_upstream_headers {
+    my ($uri) = @_;
+    my $marker = "$testdir/headers-" . marker_key($uri);
+
+    for (1 .. 300) {
+        return if -e $marker;
+        select undef, undef, undef, 0.01;
+    }
+
+    die "timeout waiting for upstream headers marker $marker\n";
+}
+
+sub marker_key {
+    my ($uri) = @_;
+
+    $uri =~ s/\?.*//;
+    $uri =~ s/[^A-Za-z0-9]+/-/g;
+    $uri =~ s/^-//;
+    $uri =~ s/-$//;
+
+    return $uri;
+}
+
+sub delayed_daemon {
+    my $server = IO::Socket::INET->new(
+        Proto => 'tcp',
+        LocalHost => '127.0.0.1:' . port(8081),
+        Listen => 5,
+        Reuse => 1
+    ) or die "Can't create listening socket: $!\n";
+
+    local $SIG{PIPE} = 'IGNORE';
+
+    while (my $client = $server->accept()) {
+        $client->autoflush(1);
+
+        my $request = <$client>;
+        if (!defined $request) {
+            close $client;
+            next;
+        }
+
+        my ($uri) = $request =~ /^\S+\s+(\S+)/;
+
+        while (<$client>) {
+            last if (/^\x0d?\x0a?$/);
+        }
+
+        print $client "HTTP/1.1 200 OK\r\n"
+            . "Content-Length: 12\r\n"
+            . "Content-Type: text/plain\r\n"
+            . "X-Delayed-Upstream: yes\r\n\r\n";
+
+        my $key = marker_key($uri // 'unknown');
+
+        open my $fh, '>', "$testdir/headers-" . $key
+            or die "Can't write upstream marker: $!\n";
+        print $fh "sent\n";
+        close $fh;
+
+        # Block until the client side signals it has captured the pre-body state
+        # (release marker).  This replaces a fixed sleep, so the body can never
+        # race into the "early" read regardless of CI scheduling latency.
+        my $release = "$testdir/release-" . $key;
+        for (1 .. 500) {
+            last if -e $release;
+            select undef, undef, undef, 0.01;
+        }
+
+        print $client "DELAYED-BODY";
+        close $client;
+    }
+}


### PR DESCRIPTION
Part of an 18-PR hardening series (numbered 01–18); each PR is independent against main, recommended review order is numeric.

**Severity:** Low

## What
New directive `coraza_response_body_delay on|off` (default `on`, preserving current behaviour).

## Why
To give phase-4 rules a chance to replace a denied response with a clean error page, the connector delays response headers until body inspection finishes — costing TTFB on every inspected response. Operators whose loaded ruleset has no phase-4 response rules pay that latency for nothing. libcoraza exposes no phase-rule introspection, so an explicit operator toggle is the only safe way to skip the delay. With `off`, phase-3/4 interventions still stop the stream mid-flight; only the clean-error-page guarantee is forfeited.

## Testing
Adds a regression test covering both directive states.

> Note: supersedes the corresponding part of #49 (closed) with a narrower, standalone fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `coraza_delay_response_headers` directive to control whether response headers are forwarded immediately or delayed until phase-4 response-body inspection.
  * Delayed header forwarding remains enabled by default and supports configuration inheritance across nested locations.
* **Bug Fixes**
  * Maintains correct phase-4 blocking behavior, including clean handling for interventions that do not produce a response body.
* **Tests**
  * Added `coraza-delay-response-headers` coverage for off/default/on modes and verified phase-4 non-body behavior remains consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->