### PR TITLE
perf: avoid copying uninspected file response buffers

### DIFF
--- a/src/ngx_http_coraza_body_filter.c
+++ b/src/ngx_http_coraza_body_filter.c
@@ -205,36 +205,58 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                 u_char    *data;
                 size_t     len;
 
-                if (ngx_http_coraza_read_body_data(r, chain->buf, &data, &len)
-                    != NGX_OK)
+                if (!ctx->response_body_processable
+                    && !ngx_buf_in_memory(chain->buf)
+                    && chain->buf->in_file
+                    && !chain->buf->temp_file)
                 {
-                    return NGX_ERROR;
-                }
-
-                b = ngx_calloc_buf(r->pool);
-                if (b == NULL) {
-                    return NGX_ERROR;
-                }
-
-                if (len > 0) {
                     /*
-                     * Always make a pool copy: in-memory buffers may point
-                     * into nginx's single reusable upstream buffer (u->buffer)
-                     * which nginx will overwrite once we mark it consumed.
+                     * No body inspection will read these bytes.  Pure
+                     * non-temp file-backed buffers can be replayed by
+                     * preserving the stable file range instead of reading it
+                     * into r->pool.  Upstream temp files keep the copy path
+                     * because their lifetime is controlled by upstream.
                      */
-                    u_char *copy = ngx_pnalloc(r->pool, len);
-                    if (copy == NULL) {
+                    b = ngx_calloc_buf(r->pool);
+                    if (b == NULL) {
                         return NGX_ERROR;
                     }
-                    ngx_memcpy(copy, data, len);
-                    b->pos    = copy;
-                    b->last   = copy + len;
-                    b->memory = 1;
-                }
 
-                b->last_buf      = 0;
-                b->last_in_chain = chain->buf->last_in_chain;
-                b->flush         = chain->buf->flush;
+                    *b = *chain->buf;
+                    b->last_buf = 0;
+
+                } else {
+                    if (ngx_http_coraza_read_body_data(r, chain->buf, &data, &len)
+                        != NGX_OK)
+                    {
+                        return NGX_ERROR;
+                    }
+
+                    b = ngx_calloc_buf(r->pool);
+                    if (b == NULL) {
+                        return NGX_ERROR;
+                    }
+
+                    if (len > 0) {
+                        /*
+                         * Always make a pool copy: in-memory buffers may point
+                         * into nginx's single reusable upstream buffer (u->buffer)
+                         * which nginx will overwrite once we mark it consumed.
+                         */
+                        u_char *copy = ngx_pnalloc(r->pool, len);
+                        if (copy == NULL) {
+                            return NGX_ERROR;
+                        }
+                        ngx_memcpy(copy, data, len);
+                        b->pos    = copy;
+                        b->last   = copy + len;
+                        b->memory = 1;
+                    }
+
+                    b->last_buf      = 0;
+                    b->last_in_chain = chain->buf->last_in_chain;
+                    b->flush         = chain->buf->flush;
+                }
 
                 /* Mark original buffer consumed so nginx may reuse it. */
                 if (ngx_buf_in_memory(chain->buf)) {

--- a/src/ngx_http_coraza_body_filter.c
+++ b/src/ngx_http_coraza_body_filter.c
@@ -208,6 +208,7 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                 if (!ctx->response_body_processable
                     && !ngx_buf_in_memory(chain->buf)
                     && chain->buf->in_file
+                    && chain->buf->file != NULL
                     && !chain->buf->temp_file)
                 {
                     /*

--- a/t/coraza-delayed-file-buffer.t
+++ b/t/coraza-delayed-file-buffer.t
@@ -26,7 +26,7 @@ select STDOUT; $| = 1;
 
 my $root = "$FindBin::Bin/..";
 my $src = slurp("$root/src/ngx_http_coraza_body_filter.c");
-my $t = Test::Nginx->new()->has(qw/http/)->plan(6);
+my $t = Test::Nginx->new()->has(qw/http/)->plan(8);
 
 like($src,
     qr/!\s*ctx->response_body_processable\s*&&\s*!\s*ngx_buf_in_memory\(chain->buf\)\s*&&\s*chain->buf->in_file\s*&&\s*!\s*chain->buf->temp_file.*?\*b\s*=\s*\*chain->buf/s,
@@ -72,6 +72,23 @@ http {
                 SecRule ARGS "@streq block" "id:161,phase:4,deny,log,status:403"
             ';
         }
+
+        # Phase-4 rule => header delivery is delayed until end-of-body, so
+        # non-final file buffers travel through the clone-and-forward branch
+        # while headers are held. The rule only logs (pass), so the full body
+        # must still be delivered intact. sendfile off + small output_buffers
+        # force the large file to arrive as several non-final file buffers.
+        location /file-delay-pass {
+            default_type application/octet-stream;
+            sendfile off;
+            output_buffers 4 8k;
+            coraza on;
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess Off
+                SecRule ARGS "@streq observe" "id:162,phase:4,pass,log"
+            ';
+        }
     }
 }
 EOF
@@ -79,6 +96,7 @@ EOF
 my $size = 128 * 1024;
 $t->write_file('/file-pass', 'F' x $size);
 $t->write_file('/file-block', 'ORIGINAL-FILE-BODY');
+$t->write_file('/file-delay-pass', 'D' x $size);
 
 $t->run();
 $t->todo_alerts();
@@ -97,6 +115,16 @@ like($r, qr/^HTTP\S+ 403/,
     'phase-4 non-body rule still cleanly blocks delayed file response');
 unlike($r, qr/ORIGINAL-FILE-BODY/,
     'clean phase-4 block does not leak original file response body');
+
+# Phase-4 pass rule holds headers while multiple non-final file buffers stream
+# through -> exercises the clone-and-forward branch (not just the final buffer).
+$r = http_get('/file-delay-pass?q=observe');
+like($r, qr/^HTTP\S+ 200/,
+    'delayed file response with cloned non-final buffers returns 200');
+
+($body) = $r =~ /\r\n\r\n(.*)$/s;
+is(length($body // ''), $size,
+    'cloned non-final file buffers deliver the full body intact');
 
 ###############################################################################
 

--- a/t/coraza-delayed-file-buffer.t
+++ b/t/coraza-delayed-file-buffer.t
@@ -1,0 +1,109 @@
+#!/usr/bin/perl
+
+# Tests for Coraza-nginx connector (delayed file-backed response buffers).
+#
+# When response body inspection is disabled, delayed pure file-backed buffers
+# can be replayed as file ranges instead of being read and copied into r->pool.
+# The runtime checks below pin the behaviour that optimization must preserve.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+use FindBin;
+
+BEGIN { chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $root = "$FindBin::Bin/..";
+my $src = slurp("$root/src/ngx_http_coraza_body_filter.c");
+my $t = Test::Nginx->new()->has(qw/http/)->plan(6);
+
+like($src,
+    qr/!\s*ctx->response_body_processable\s*&&\s*!\s*ngx_buf_in_memory\(chain->buf\)\s*&&\s*chain->buf->in_file\s*&&\s*!\s*chain->buf->temp_file.*?\*b\s*=\s*\*chain->buf/s,
+    'uninspected non-temp file-backed delayed buffers are cloned without body copy');
+
+like($src,
+    qr/\*b\s*=\s*\*chain->buf;.*?chain->buf->file_pos\s*=\s*chain->buf->file_last/s,
+    'cloned file-backed source buffers are still marked consumed');
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+        root         %%TESTDIR%%;
+        sendfile     on;
+
+        location /file-pass {
+            default_type application/octet-stream;
+            coraza on;
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess Off
+            ';
+        }
+
+        location /file-block {
+            default_type text/plain;
+            coraza on;
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess Off
+                SecRule ARGS "@streq block" "id:161,phase:4,deny,log,status:403"
+            ';
+        }
+    }
+}
+EOF
+
+my $size = 128 * 1024;
+$t->write_file('/file-pass', 'F' x $size);
+$t->write_file('/file-block', 'ORIGINAL-FILE-BODY');
+
+$t->run();
+$t->todo_alerts();
+
+###############################################################################
+
+my $r = http_get('/file-pass');
+like($r, qr/^HTTP\S+ 200/, 'uninspected delayed file response returns 200');
+
+my ($body) = $r =~ /\r\n\r\n(.*)$/s;
+is(length($body // ''), $size,
+    'uninspected delayed file response body is delivered intact');
+
+$r = http_get('/file-block?q=block');
+like($r, qr/^HTTP\S+ 403/,
+    'phase-4 non-body rule still cleanly blocks delayed file response');
+unlike($r, qr/ORIGINAL-FILE-BODY/,
+    'clean phase-4 block does not leak original file response body');
+
+###############################################################################
+
+sub slurp {
+    my ($path) = @_;
+
+    open my $fh, '<', $path or die "open $path: $!";
+    local $/ = undef;
+    return <$fh>;
+}

--- a/t/coraza-delayed-file-buffer.t
+++ b/t/coraza-delayed-file-buffer.t
@@ -29,7 +29,7 @@ my $src = slurp("$root/src/ngx_http_coraza_body_filter.c");
 my $t = Test::Nginx->new()->has(qw/http/)->plan(8);
 
 like($src,
-    qr/!\s*ctx->response_body_processable\s*&&\s*!\s*ngx_buf_in_memory\(chain->buf\)\s*&&\s*chain->buf->in_file\s*&&\s*!\s*chain->buf->temp_file.*?\*b\s*=\s*\*chain->buf/s,
+    qr/!\s*ctx->response_body_processable\s*&&\s*!\s*ngx_buf_in_memory\(chain->buf\)\s*&&\s*chain->buf->in_file\s*&&\s*chain->buf->file\s*!=\s*NULL\s*&&\s*!\s*chain->buf->temp_file.*?\*b\s*=\s*\*chain->buf/s,
     'uninspected non-temp file-backed delayed buffers are cloned without body copy');
 
 like($src,


### PR DESCRIPTION
Part of an 18-PR hardening series (numbered 01–18); each PR is independent against main, recommended review order is numeric.

**Severity:** Low

## What
When response-body inspection is off for a transaction (`SecResponseBodyAccess Off` / non-matching MIME type), pass non-temp file buffers through as file-range clones instead of reading them into a pool copy.

## Why
The filter memcpy'd every response buffer into `r->pool` even when the WAF never looks at the body. For static-file responses this doubles memory traffic and defeats nginx's zero-copy file path. In-memory buffers still get a pool copy (they may point into the reusable upstream buffer), and temp-file buffers keep the old path.

## Testing
Adds a regression test; existing response-body tests cover the inspected path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of delayed, file-backed response buffers to avoid unnecessary body copying when response inspection is disabled.
  * Preserved correct delivery behavior for large file responses, including proper blocking without unintended content exposure.
* **Tests**
  * Added a new nginx-based test covering delayed file-buffer scenarios to verify both pass and deny outcomes and that delayed bodies are handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->