### PR TITLE
fix: clear entity headers on synthesized redirects

### DIFF
--- a/src/ngx_http_coraza_header_filter.c
+++ b/src/ngx_http_coraza_header_filter.c
@@ -465,13 +465,35 @@ ngx_http_coraza_header_filter(ngx_http_request_t *r)
             r->err_status = 0;
             r->header_only = 1;
 
-            /* Clear entity headers from the original response to avoid
-             * protocol-inconsistent redirects (e.g. 3xx with Content-Length
-             * but no body). */
+            /* Clear entity/representation headers carried over from the
+             * original response so the synthesized 3xx redirect is not
+             * protocol-inconsistent (RFC 9110 §15.4 / §8.3-8.8): a body-less
+             * redirect must not advertise Content-Length, Content-Type,
+             * Content-Encoding, Last-Modified, ETag or Accept-Ranges that
+             * describe the representation we are discarding. */
             r->headers_out.content_length_n = -1;
             if (r->headers_out.content_length) {
                 r->headers_out.content_length->hash = 0;
                 r->headers_out.content_length = NULL;
+            }
+            ngx_str_null(&r->headers_out.content_type);
+            r->headers_out.content_type_len = 0;
+            r->headers_out.last_modified_time = -1;
+            if (r->headers_out.last_modified) {
+                r->headers_out.last_modified->hash = 0;
+                r->headers_out.last_modified = NULL;
+            }
+            if (r->headers_out.content_encoding) {
+                r->headers_out.content_encoding->hash = 0;
+                r->headers_out.content_encoding = NULL;
+            }
+            if (r->headers_out.etag) {
+                r->headers_out.etag->hash = 0;
+                r->headers_out.etag = NULL;
+            }
+            if (r->headers_out.accept_ranges) {
+                r->headers_out.accept_ranges->hash = 0;
+                r->headers_out.accept_ranges = NULL;
             }
 
             return ngx_http_next_header_filter(r);

--- a/src/ngx_http_coraza_header_filter.c
+++ b/src/ngx_http_coraza_header_filter.c
@@ -491,10 +491,7 @@ ngx_http_coraza_header_filter(ngx_http_request_t *r)
                 r->headers_out.etag->hash = 0;
                 r->headers_out.etag = NULL;
             }
-            if (r->headers_out.accept_ranges) {
-                r->headers_out.accept_ranges->hash = 0;
-                r->headers_out.accept_ranges = NULL;
-            }
+            ngx_http_clear_accept_ranges(r);
 
             return ngx_http_next_header_filter(r);
         }

--- a/t/coraza-redirect-entity-headers.t
+++ b/t/coraza-redirect-entity-headers.t
@@ -1,0 +1,80 @@
+#!/usr/bin/perl
+
+# Tests for Coraza-nginx connector (RFC 9110 §15.4 redirect hygiene).
+#
+# When a phase-3 rule turns an already-populated 200 response into a 3xx
+# redirect (redirect: action -> intervention with a Location), the connector
+# synthesizes the Location + status but must also drop the entity/representation
+# headers carried over from the discarded 200 response.  Otherwise the body-less
+# redirect advertises Content-Type / Content-Length / Last-Modified / ETag /
+# Accept-Ranges describing a representation it no longer sends -- a
+# protocol-inconsistent response (RFC 9110 §15.4 / §8.3-8.8).
+# See src/ngx_http_coraza_header_filter.c (redirect branch entity-header clear).
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http/)->plan(7);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:%%PORT_8080%%;
+        server_name  localhost;
+
+        location /static/ {
+            alias %%TESTDIR%%/;
+
+            coraza on;
+            coraza_rules '
+                SecRuleEngine On
+                SecRule REQUEST_URI "@rx ." "id:100,phase:3,status:302,redirect:http://example.org/blocked,log"
+            ';
+        }
+    }
+}
+EOF
+
+# A static file so the original 200 carries the full entity-header set
+# (Content-Type, Content-Length, Last-Modified, ETag, Accept-Ranges).
+$t->write_file('page.html', 'body content that is discarded by the redirect');
+
+$t->run();
+
+###############################################################################
+
+my $r = http_get('/static/page.html');
+
+like($r, qr!^HTTP/\S+ 302!, 'phase-3 redirect turns 200 into 302');
+like($r, qr!Location: http://example\.org/blocked!, 'Location header present');
+
+# The discarded 200 representation's entity headers must be gone.
+unlike($r, qr/^Content-Type:/mi, 'Content-Type cleared on redirect');
+unlike($r, qr/^Content-Length: \d/mi, 'Content-Length cleared on redirect');
+unlike($r, qr/^Last-Modified:/mi, 'Last-Modified cleared on redirect');
+unlike($r, qr/^ETag:/mi, 'ETag cleared on redirect');
+unlike($r, qr/^Accept-Ranges:/mi, 'Accept-Ranges cleared on redirect');


### PR DESCRIPTION
Part of an 18-PR hardening series (numbered 01–18); each PR is independent against main, recommended review order is numeric.

**Severity:** Low

## What
When a phase-3 rule turns an already-populated 200 response into a redirect (`redirect:` action), clear the full entity/representation header set of the discarded response, not just `Content-Length`.

## Why
The header filter synthesizes the `Location` and status but left `Content-Type`, `Content-Encoding`, `Last-Modified`, `ETag` and `Accept-Ranges` describing a representation the redirect no longer sends — protocol-inconsistent per RFC 9110 §15.4 / §8.3–8.8.

## Testing
Adds `t/coraza-redirect-entity-headers.t`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redirect responses so they no longer carry over body-related headers from the original response.
  * Ensured redirects keep only the appropriate `Location` header and omit stale metadata like content type, length, last modified, ETag, and range information.

* **Tests**
  * Added coverage for redirect responses to verify that representation headers are properly cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->