### PR TITLE
fix: do not synthesize Connection/Keep-Alive for the WAF on HTTP/2

### DIFF
--- a/src/ngx_http_coraza_header_filter.c
+++ b/src/ngx_http_coraza_header_filter.c
@@ -222,6 +222,20 @@ ngx_http_coraza_resolv_header_connection(ngx_http_request_t *r, ngx_str_t name, 
     clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
     ctx = ngx_http_get_module_ctx(r, ngx_http_coraza_module);
 
+#if (NGX_HTTP_V2)
+    if (r->stream) {
+        /*
+         * HTTP/2 carries no Connection or Keep-Alive header: RFC 9113 §8.2.2
+         * forbids these connection-specific header fields and nginx never
+         * emits them on an h2 stream.  Synthesizing a phantom
+         * Connection/Keep-Alive here would make the WAF inspect a header the
+         * client never receives -- e.g. a rule on RESPONSE_HEADERS:Connection
+         * would false-positive on every HTTP/2 response.
+         */
+        return NGX_OK;
+    }
+#endif
+
     if (r->headers_out.status == NGX_HTTP_SWITCHING_PROTOCOLS) {
         connection = "upgrade";
     } else if (r->keepalive) {

--- a/src/ngx_http_coraza_header_filter.c
+++ b/src/ngx_http_coraza_header_filter.c
@@ -222,19 +222,19 @@ ngx_http_coraza_resolv_header_connection(ngx_http_request_t *r, ngx_str_t name, 
     clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
     ctx = ngx_http_get_module_ctx(r, ngx_http_coraza_module);
 
-#if (NGX_HTTP_V2)
-    if (r->stream) {
+    if (r->http_version >= NGX_HTTP_VERSION_20) {
         /*
-         * HTTP/2 carries no Connection or Keep-Alive header: RFC 9113 §8.2.2
-         * forbids these connection-specific header fields and nginx never
-         * emits them on an h2 stream.  Synthesizing a phantom
-         * Connection/Keep-Alive here would make the WAF inspect a header the
-         * client never receives -- e.g. a rule on RESPONSE_HEADERS:Connection
-         * would false-positive on every HTTP/2 response.
+         * HTTP/2 (RFC 9113 §8.2.2) and HTTP/3 (RFC 9114 §4.2) both forbid the
+         * connection-specific header fields Connection and Keep-Alive, and
+         * nginx never emits them on an h2 stream or an h3 request.  Synthesizing
+         * a phantom Connection/Keep-Alive here would make the WAF inspect a
+         * header the client never receives -- e.g. a rule on
+         * RESPONSE_HEADERS:Connection would false-positive on every HTTP/2 and
+         * HTTP/3 response.  A version check (rather than r->stream, which is
+         * h2-only and NULL for h3) covers both protocols.
          */
         return NGX_OK;
     }
-#endif
 
     if (r->headers_out.status == NGX_HTTP_SWITCHING_PROTOCOLS) {
         connection = "upgrade";

--- a/t/coraza-h2-forbidden-headers.t
+++ b/t/coraza-h2-forbidden-headers.t
@@ -4,18 +4,24 @@
 #
 # The connector synthesizes a Connection response header (and, when
 # keepalive_timeout carries a header timeout, a Keep-Alive header) and feeds it
-# to the WAF for inspection.  HTTP/2 forbids these connection-specific header
-# fields (RFC 9113 §8.2.2) and nginx never emits them on an h2 stream, so they
-# must NOT be synthesized for the WAF either -- otherwise a rule on
-# RESPONSE_HEADERS:Connection false-positives on every HTTP/2 response.
+# to the WAF for inspection.  HTTP/2 (RFC 9113 §8.2.2) and HTTP/3 (RFC 9114
+# §4.2) both forbid these connection-specific header fields, and nginx never
+# emits them on an h2 stream or an h3 request, so they must NOT be synthesized
+# for the WAF either -- otherwise a rule on RESPONSE_HEADERS:Connection
+# false-positives on every HTTP/2 and HTTP/3 response.
+#
+# The guard is a version check (r->http_version >= NGX_HTTP_VERSION_20), which
+# covers h2 and h3 alike -- r->stream is h2-only and NULL for h3.  This test
+# exercises the h1-vs-h2 boundary; h3 shares the identical code path and is not
+# separately scaffolded here (the harness has no QUIC/TLS setup).
 #
 # The same location is reachable over HTTP/1.1 (port 8080) and HTTP/2
 # (port 8081).  A phase-3 deny rule keyed on the synthetic Connection header
 # must fire over h1 (the header is present) but not over h2 (the header must be
 # absent from the WAF's view).  Connection is always synthesized, so it
-# exercises the h2 guard directly; the same early return also suppresses the
-# Keep-Alive synthesis.
-# See src/ngx_http_coraza_header_filter.c (resolv_header_connection h2 guard).
+# exercises the version guard directly; the same early return also suppresses
+# the Keep-Alive synthesis.
+# See src/ngx_http_coraza_header_filter.c (resolv_header_connection version guard).
 
 ###############################################################################
 

--- a/t/coraza-h2-forbidden-headers.t
+++ b/t/coraza-h2-forbidden-headers.t
@@ -1,0 +1,83 @@
+#!/usr/bin/perl
+
+# Tests for Coraza-nginx connector (HTTP/2 hop-by-hop header hygiene).
+#
+# The connector synthesizes a Connection response header (and, when
+# keepalive_timeout carries a header timeout, a Keep-Alive header) and feeds it
+# to the WAF for inspection.  HTTP/2 forbids these connection-specific header
+# fields (RFC 9113 §8.2.2) and nginx never emits them on an h2 stream, so they
+# must NOT be synthesized for the WAF either -- otherwise a rule on
+# RESPONSE_HEADERS:Connection false-positives on every HTTP/2 response.
+#
+# The same location is reachable over HTTP/1.1 (port 8080) and HTTP/2
+# (port 8081).  A phase-3 deny rule keyed on the synthetic Connection header
+# must fire over h1 (the header is present) but not over h2 (the header must be
+# absent from the WAF's view).  Connection is always synthesized, so it
+# exercises the h2 guard directly; the same early return also suppresses the
+# Keep-Alive synthesis.
+# See src/ngx_http_coraza_header_filter.c (resolv_header_connection h2 guard).
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+use Test::Nginx::HTTP2;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http http_v2/)->plan(2);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        listen       127.0.0.1:8081 http2;
+        server_name  localhost;
+
+        location /conn {
+            coraza on;
+            coraza_rules '
+                SecRuleEngine On
+                SecRule RESPONSE_HEADERS:Connection "@rx .+" "id:20,phase:3,deny,status:403,log"
+            ';
+            return 200 "ok";
+        }
+    }
+}
+EOF
+
+$t->run();
+
+###############################################################################
+
+# HTTP/1.1: the synthetic Connection header is present, so the phase-3 rule
+# matches and blocks with 403.
+like(http_get('/conn'), qr!^HTTP/\S+ 403!, 'h1: synthetic Connection seen by WAF');
+
+# HTTP/2: Connection is forbidden and must not be synthesized, so the rule does
+# not match and the request passes.
+my $s = Test::Nginx::HTTP2->new(8081);
+my $sid = $s->new_stream({ path => '/conn' });
+my $frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+my ($frame) = grep { $_->{type} eq 'HEADERS' } @$frames;
+is($frame->{headers}->{':status'}, 200, 'h2: no synthetic Connection, request passes');


### PR DESCRIPTION
Part of an 18-PR hardening series (numbered 01–18); each PR is independent against main, recommended review order is numeric.

**Severity:** Low

## What
Skip synthesizing `Connection` / `Keep-Alive` headers for WAF inspection when `r->stream` is set (HTTP/2).

## Why
The response-header resolver synthesizes a `Connection` header (and `Keep-Alive` when `keepalive_timeout` carries a header timeout) and feeds it to Coraza. HTTP/2 forbids connection-specific header fields (RFC 9113 §8.2.2) and nginx never emits them on an h2 stream, so the WAF inspects a header the client never receives — a rule on `RESPONSE_HEADERS:Connection` would false-positive on every h2 response. `Transfer-Encoding` is already gated on `r->chunked`, which nginx never sets on an h2 stream.

## Testing
Adds `t/coraza-h2-forbidden-headers.t`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP/2+ response handling to avoid synthesizing or exposing connection-related headers such as `Connection`/`Keep-Alive` on stream-based responses.
  * This reduces cases where the WAF could observe these hop-by-hop headers inappropriately.

* **Tests**
  * Added a new HTTP/2-specific test covering forbidden response header hygiene.
  * Verifies `RESPONSE_HEADERS:Connection` triggers under HTTP/1.1 while HTTP/2 correctly keeps the synthetic `Connection` header from being visible to policy evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->