### PR TITLE
harden: sanitize control bytes in synthesized Location header

### DIFF
--- a/src/ngx_http_coraza_module.c
+++ b/src/ngx_http_coraza_module.c
@@ -91,6 +91,30 @@ ngx_http_coraza_process_intervention(coraza_transaction_t transaction, ngx_http_
 			if (h != NULL)
 			{
 				size_t len = ngx_strlen(intervention->data);
+				/*
+				 * Defend against response splitting / header injection.
+				 * If a rule builds the redirect target from
+				 * client-controlled data (macro expansion of a request
+				 * variable), intervention->data may contain CR/LF or other
+				 * control bytes.  nginx does not sanitize outgoing header
+				 * values, so a raw CR/LF here would let an attacker inject
+				 * extra response headers or a body.  Truncate the Location
+				 * at the first C0 control character or DEL (a legitimate
+				 * URL carries none unencoded).
+				 */
+				{
+					u_char *loc = (u_char *) intervention->data;
+					size_t safe = 0;
+					while (safe < len && loc[safe] >= 0x20 && loc[safe] != 0x7f) {
+						safe++;
+					}
+					if (safe != len) {
+						ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
+							"coraza: control character in redirect target; "
+							"truncating Location to %uz byte(s)", safe);
+						len = safe;
+					}
+				}
 				h->hash = 0;
 				ngx_str_set(&h->key, "Location");
 				h->value.len = 0;

--- a/t/coraza-location-sanitize.t
+++ b/t/coraza-location-sanitize.t
@@ -1,0 +1,73 @@
+#!/usr/bin/perl
+
+# Tests for Coraza-nginx connector (Location sanitization, no-regression).
+#
+# ngx_http_coraza_process_intervention copies intervention->data into the
+# Location header on a redirect, now truncating at the first control byte to
+# defend against CR/LF response splitting should that data ever carry
+# client-controlled bytes.  A clean redirect target contains no control bytes,
+# so it must pass through byte-for-byte unchanged.
+#
+# NOTE: libcoraza 1.4 does not macro-expand the redirect: target (verified: a
+# %{ARGS.x} target reaches Location literally), so client data cannot reach
+# intervention->data through a normal rule today -- the sanitization is
+# defense-in-depth for future/dynamic sources and cannot be positively
+# exercised for the injection case through the rule engine.  This test pins the
+# no-regression behaviour.
+# See src/ngx_http_coraza_module.c (ngx_http_coraza_process_intervention).
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http/)->plan(2);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location /redir {
+            coraza on;
+            coraza_rules '
+                SecRuleEngine On
+                SecRule ARGS:x "@streq go" "id:30,phase:1,status:302,redirect:http://example.org/clean/path?a=b,log"
+            ';
+        }
+    }
+}
+EOF
+
+$t->run();
+
+###############################################################################
+
+my $r = http_get('/redir?x=go');
+
+like($r, qr!^HTTP/\S+ 302!, 'clean redirect returns 302');
+like($r, qr!Location: http://example\.org/clean/path\?a=b\r?\n!,
+    'clean Location passes through unchanged (no truncation)');


### PR DESCRIPTION
Part of an 18-PR hardening series (numbered 01–18); each PR is independent against main, recommended review order is numeric.

**Severity:** Low

## What
Truncate the synthesized `Location` header at the first C0 control character or DEL before copying `intervention->data` into the response; log a warning when the guard fires.

## Why
`ngx_http_coraza_process_intervention` copies `intervention->data` verbatim into `Location` on a redirect. nginx does not sanitize outgoing header values, so a CR/LF in that data would be emitted raw — HTTP response splitting / header injection. A legitimate URL carries no unencoded control bytes.

**Severity note:** defense-in-depth. libcoraza 1.4 does NOT macro-expand the `redirect:` target (verified: a `%{ARGS.x}` target reaches `Location` literally), so `intervention->data` is the static rule-author string and client data cannot reach it through a normal rule today. The guard future-proofs against a libcoraza that gains redirect macro expansion (upstream Coraza supports it) or any other dynamic source, at negligible cost.

## Testing
Adds `t/coraza-location-sanitize.t` (a clean redirect target passes through byte-for-byte, confirming no over-truncation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redirect handling by sanitizing outgoing `Location` header values to prevent control bytes from being included in redirect targets.
  * When unsafe bytes are detected, the redirect target is truncated and a warning is logged to keep headers safe.

* **Tests**
  * Added a regression test to verify 302 redirect responses return the expected `Location` header without unintended truncation/sanitization effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->