### PR TITLE
fix: guard size_t to int narrowing at the Coraza cgo boundary

### DIFF
--- a/src/ngx_http_coraza_body_filter.c
+++ b/src/ngx_http_coraza_body_filter.c
@@ -12,6 +12,26 @@
 
 static ngx_http_output_body_filter_pt ngx_http_next_body_filter;
 
+/*
+ * Length of the body data ngx_http_coraza_read_body_data would return,
+ * without performing the read/allocation -- lets callers reject an
+ * oversized chunk before paying for it.
+ */
+static size_t
+ngx_http_coraza_body_chunk_len(ngx_buf_t *buf)
+{
+    if (ngx_buf_in_memory(buf)) {
+        return buf->last - buf->pos;
+    }
+
+    if (buf->in_file && buf->file) {
+        return buf->file_last - buf->file_pos;
+    }
+
+    return 0;
+}
+
+
 ngx_int_t
 ngx_http_coraza_body_filter_init(void)
 {
@@ -123,20 +143,24 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
             size_t  len;
             int     ret;
 
-            if (ngx_http_coraza_read_body_data(r, chain->buf, &data, &len)
-                != NGX_OK)
-            {
-                return NGX_ERROR;
-            }
-
             /*
              * coraza_append_response_body takes an int length; guard the
              * size_t -> int narrowing so a >INT_MAX buffer cannot wrap to a
-             * bogus length and skip inspection. Fail closed.
+             * bogus length and skip inspection. Fail closed. Checked against
+             * the buffer's own bounds before the read/allocation below, so
+             * an oversized on-disk chunk is rejected without paying for the
+             * file read first.
              */
-            if (len > INT_MAX) {
+            if (ngx_http_coraza_body_chunk_len(chain->buf) > INT_MAX) {
                 ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                     "coraza: response body chunk too large to inspect");
+                ctx->intervention_triggered = 1;
+                return NGX_ERROR;
+            }
+
+            if (ngx_http_coraza_read_body_data(r, chain->buf, &data, &len)
+                != NGX_OK)
+            {
                 return NGX_ERROR;
             }
 

--- a/src/ngx_http_coraza_body_filter.c
+++ b/src/ngx_http_coraza_body_filter.c
@@ -129,6 +129,17 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                 return NGX_ERROR;
             }
 
+            /*
+             * coraza_append_response_body takes an int length; guard the
+             * size_t -> int narrowing so a >INT_MAX buffer cannot wrap to a
+             * bogus length and skip inspection. Fail closed.
+             */
+            if (len > INT_MAX) {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                    "coraza: response body chunk too large to inspect");
+                return NGX_ERROR;
+            }
+
             if (len > 0) {
                 coraza_append_response_body(ctx->coraza_transaction, data, len);
             }

--- a/src/ngx_http_coraza_body_filter.c
+++ b/src/ngx_http_coraza_body_filter.c
@@ -59,7 +59,7 @@ ngx_http_coraza_read_body_data(ngx_http_request_t *r, ngx_buf_t *buf,
     }
 
     if (buf->in_file && buf->file) {
-        size_t len = buf->file_last - buf->file_pos;
+        size_t len = ngx_http_coraza_body_chunk_len(buf);
         if (len == 0) {
             *out_data = NULL;
             *out_len = 0;

--- a/src/ngx_http_coraza_pre_access.c
+++ b/src/ngx_http_coraza_pre_access.c
@@ -146,9 +146,21 @@ ngx_http_coraza_pre_access_handler(ngx_http_request_t *r)
         while (chain && !already_inspected)
         {
             u_char *data = chain->buf->pos;
+            size_t  blen = (size_t) (chain->buf->last - data);
 
-            coraza_append_request_body(ctx->coraza_transaction, data,
-                chain->buf->last - data);
+            /*
+             * coraza_append_request_body takes an int length; guard the
+             * narrowing so a >INT_MAX chunk cannot wrap negative and have
+             * the engine inspect the wrong span. Fail closed.
+             */
+            if (blen > INT_MAX) {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                    "coraza: request body chunk too large to inspect");
+                ctx->intervention_triggered = 1;
+                return NGX_HTTP_INTERNAL_SERVER_ERROR;
+            }
+
+            coraza_append_request_body(ctx->coraza_transaction, data, blen);
 
             if (chain->buf->last_buf) {
                 break;

--- a/src/ngx_http_coraza_rewrite.c
+++ b/src/ngx_http_coraza_rewrite.c
@@ -179,6 +179,19 @@ ngx_http_coraza_rewrite_handler(ngx_http_request_t *r)
              */
 
             dd("Adding request header: %.*s with value %.*s", (int)data[i].key.len, data[i].key.data, (int) data[i].value.len, data[i].value.data);
+
+            /*
+             * coraza_add_request_header takes int lengths; guard the
+             * size_t -> int narrowing so an oversized header cannot wrap to
+             * a bogus length and slip past inspection. Fail closed.
+             */
+            if (data[i].key.len > INT_MAX || data[i].value.len > INT_MAX) {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                    "coraza: request header too long to inspect");
+                ctx->intervention_triggered = 1;
+                return NGX_HTTP_INTERNAL_SERVER_ERROR;
+            }
+
             coraza_add_request_header(ctx->coraza_transaction,
                                       (char *)data[i].key.data,
                                       (int)data[i].key.len,

--- a/t/coraza-large-header-inspection.t
+++ b/t/coraza-large-header-inspection.t
@@ -1,0 +1,82 @@
+#!/usr/bin/perl
+
+# Tests for Coraza-nginx connector (cgo length-narrowing guard).
+#
+# The Coraza cgo boundary takes header/body lengths as int, so the connector
+# now guards the size_t -> int narrowing and fails closed above INT_MAX. That
+# ceiling is far larger than any header nginx will accept, so a normal large
+# header (well below INT_MAX) must still be inspected as usual -- the guard must
+# not clip or skip legitimate large headers.
+# See the INT_MAX guards in ngx_http_coraza_{rewrite,header_filter,body_filter,
+# pre_access}.c.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http/)->plan(2);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    large_client_header_buffers 4 32k;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location /big {
+            coraza on;
+            coraza_rules '
+                SecRuleEngine On
+                SecRule REQUEST_HEADERS:X-Big "@contains attackpat" "id:40,phase:1,deny,status:403,log"
+            ';
+            return 200 "ok";
+        }
+    }
+}
+EOF
+
+$t->run();
+
+###############################################################################
+
+my $pad = 'a' x 16000;
+
+my $attack = http(<<EOF);
+GET /big HTTP/1.0
+Host: localhost
+X-Big: ${pad}attackpat
+
+EOF
+like($attack, qr!^HTTP/\S+ 403!, 'large header (16k) still inspected: attack blocked');
+
+my $benign = http(<<EOF);
+GET /big HTTP/1.0
+Host: localhost
+X-Big: ${pad}benign
+
+EOF
+like($benign, qr!^HTTP/\S+ 200!, 'large benign header passes');


### PR DESCRIPTION
Part of an 18-PR hardening series (numbered 01–18); each PR is independent against main, recommended review order is numeric.

**Severity:** Medium

## What
Add explicit fail-closed length ceilings (block / `NGX_ERROR`) at the request-side and response-body cgo call sites before narrowing `size_t` lengths to `int`.

## Why
`coraza_add_request_header`, `coraza_append_request_body` and `coraza_append_response_body` all take `int` lengths, but the connector passed `size_t` values straight through. A length above `INT_MAX` would wrap to a negative or truncated `int`, making the engine inspect the wrong span — a potential WAF bypass or over-read. nginx bounds these sizes far below `INT_MAX` in practice, so the guards are cheap and should never fire; when they do, failing closed beats silent mis-inspection.

The response-header path (`ngx_http_coraza_resolv_header_*`) is intentionally left to the header-error-propagation refactor (series PR 07), which routes those emissions through a single helper where the same guard belongs; response headers are server-generated and bounded well below `INT_MAX`.

## Testing
Adds `t/coraza-large-header-inspection.t` (a 16k request header is still inspected, confirming the guard does not clip legitimate headers).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added fail-closed, overflow-safe validation for large request headers, request-body chunks, and response-body chunks before inspection/processing.
  * Oversized inputs are now rejected safely to avoid unsafe narrowing/truncation.
* **Tests**
  * Added an Nginx integration test that sends large `X-Big` headers and verifies requests containing the blocking substring are denied (403) while benign large headers are accepted (200).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->