### PR TITLE
Fix NGX_AGAIN body truncation in the delayed-buffer cap flush

### DIFF
--- a/src/ngx_http_coraza_body_filter.c
+++ b/src/ngx_http_coraza_body_filter.c
@@ -359,9 +359,18 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 
             ctx->headers_delayed = 0;
 
+            /*
+             * Short-circuit only on NGX_ERROR.  forward_header() can return
+             * NGX_AGAIN (write filter buffered the headers but couldn't flush
+             * them yet); bailing here would leave pending_chain unsent and
+             * truncate the body.  Fall through and hand it to the body filter,
+             * whose return value carries the NGX_AGAIN up so the retry flushes
+             * headers and body together (same contract as the end-of-body
+             * flush above).
+             */
             rc = ngx_http_coraza_forward_header(r);
-            if (rc != NGX_OK) {
-                return rc;
+            if (rc == NGX_ERROR) {
+                return NGX_ERROR;
             }
 
             out = ctx->pending_chain;


### PR DESCRIPTION
The delayed-response-body cap flush added in #71 short-circuits on any
non-OK return from `ngx_http_coraza_forward_header()`:

```c
rc = ngx_http_coraza_forward_header(r);
if (rc != NGX_OK) { return rc; }
```

`forward_header` bottoms out in the write filter, which returns `NGX_AGAIN`
when headers are buffered but not fully flushed (full socket buffer, or
`limit_rate` throttling). Bailing on `NGX_AGAIN` returns before `pending_chain`
is handed to the body filter, so the buffered body is stranded and the
response is truncated — the same bug #69 fixed in the end-of-body flush.

Fix mirrors #69: bail only on `NGX_ERROR`, and let the body filter forward
`pending_chain` (its return carries `NGX_AGAIN` up so the retry flushes
headers + body together).

This also fixes the `coraza-forward-header-rc.t` failure on main — #69's
regression guard correctly flagged the reintroduced pattern in the cap path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delayed response handling when headers are temporarily buffered.
  * Ensures accumulated response content is forwarded correctly and retry behavior is preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->