### PR TITLE
fix: don't delay response headers for SSE streams (#81)

### DIFF
--- a/src/ngx_http_coraza_header_filter.c
+++ b/src/ngx_http_coraza_header_filter.c
@@ -182,6 +182,64 @@ ngx_http_coraza_resolv_header_content_type(ngx_http_request_t *r, ngx_str_t name
 }
 
 
+/*
+ * A streaming response has no meaningful end-of-body: the origin emits events
+ * indefinitely and never sends a last_buf, so the header-delay flush (which
+ * fires on last_buf) holds the response headers until the delayed-body cap
+ * (NGX_HTTP_CORAZA_MAX_DELAYED_BODY) is reached.  A real SSE endpoint emits a
+ * few bytes per event, so that cap is reached only after minutes or hours --
+ * in practice the client receives nothing (issue #81).
+ *
+ * Detect Server-Sent Events (Content-Type: text/event-stream) so the caller
+ * can skip the delay, exactly as it does for 101 Switching Protocols.
+ *
+ * SECURITY TRADE-OFF: Content-Type is chosen by the upstream, so an origin
+ * that emits text/event-stream opts this response out of the phase-4 header
+ * delay.  Phase 4 still RUNS on such a response (the body filter always calls
+ * coraza_process_response_body()), and phase 1-3 are untouched -- what is lost
+ * is only the ability to turn a phase-4 match into a clean error page, because
+ * the headers are already on the wire.  A late match degrades to a connection
+ * reset instead.  That is the same trade-off 101 Switching Protocols already
+ * accepts, and it is inherent: streaming and full-response WAF buffering are
+ * mutually exclusive by construction.  Operators who do not proxy untrusted
+ * origins and want the delay unconditionally can leave their upstreams from
+ * emitting text/event-stream, or disable streaming endpoints at the proxy.
+ */
+static ngx_int_t
+ngx_http_coraza_is_sse_response(ngx_http_request_t *r)
+{
+    ngx_str_t *ct = &r->headers_out.content_type;
+    static const u_char sse[] = "text/event-stream";
+    size_t sse_len = sizeof(sse) - 1;
+    size_t i;
+
+    if (ct->len < sse_len) {
+        return 0;
+    }
+
+    /* Match the media type; tolerate a trailing "; charset=..." etc. */
+    if (ngx_strncasecmp(ct->data, (u_char *) sse, sse_len) != 0) {
+        return 0;
+    }
+
+    /*
+     * The media type must be followed by end-of-value or a semicolon-
+     * delimited parameter list, with optional OWS (SP / HTAB, RFC 9110
+     * 5.6.3) before the semicolon.  Anything else ("text/event-streamx",
+     * "text/event-stream application/json") is NOT SSE and must keep the
+     * phase-4 header delay.
+     */
+    for (i = sse_len; i < ct->len; i++) {
+        if (ct->data[i] == ' ' || ct->data[i] == '\t') {
+            continue;
+        }
+        return ct->data[i] == ';';
+    }
+
+    return 1;
+}
+
+
 static ngx_int_t
 ngx_http_coraza_resolv_header_last_modified(ngx_http_request_t *r, ngx_str_t name, off_t offset)
 {
@@ -524,11 +582,19 @@ ngx_http_coraza_header_filter(ngx_http_request_t *r)
      * body, so the body filter never sees a last_buf to trigger the flush.
      * Delaying the 101 would hold the handshake forever and the upgrade
      * would never complete.
+     *
+     * We likewise skip Server-Sent Events (Content-Type: text/event-stream):
+     * an SSE stream emits events indefinitely and never sends a last_buf, so
+     * the headers would be held until the delayed-body cap forces a flush --
+     * minutes or hours on a real event stream, i.e. the client gets nothing
+     * (issue #81).  See ngx_http_coraza_is_sse_response() above for the
+     * security trade-off this accepts.
      */
     if (mcf->delay_response_headers
         && r->method != NGX_HTTP_HEAD && !r->header_only && !r->error_page
         && r == r->main
-        && r->headers_out.status != NGX_HTTP_SWITCHING_PROTOCOLS)
+        && r->headers_out.status != NGX_HTTP_SWITCHING_PROTOCOLS
+        && !ngx_http_coraza_is_sse_response(r))
     {
         /*
          * Delay sending headers until phase 4 completes so that

--- a/t/coraza-sse.t
+++ b/t/coraza-sse.t
@@ -1,0 +1,225 @@
+#!/usr/bin/perl
+
+# Tests for Coraza-nginx connector (Server-Sent Events, text/event-stream).
+#
+# Regression test for issue #81: the connector delays response headers until
+# phase-4 body inspection completes at last_buf, but an SSE stream emits events
+# indefinitely and never sends a last_buf, so the headers (and every event)
+# were held forever and the client received 0 bytes -- even in DetectionOnly.
+# The header filter now skips the delay for Content-Type: text/event-stream,
+# exactly as it does for a 101 upgrade.
+#
+# The upstream daemon streams heartbeat events until the client disconnects
+# and never closes the connection on its own, so the delayed-header path can
+# never be rescued by an upstream-close last_buf flush: only prompt delivery
+# passes the positive assertions (the test fails on the pre-fix code).
+#
+# Near-miss content types ("text/event-streamx", "text/event-stream junk")
+# must NOT get the exemption: those requests assert that nothing reaches the
+# client early, i.e. the phase-4 header delay is still in force.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+use IO::Socket::INET;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(10);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location / {
+            coraza on;
+            coraza_rules '
+                SecRuleEngine DetectionOnly
+                SecResponseBodyAccess On
+            ';
+            proxy_pass http://127.0.0.1:8081;
+            proxy_read_timeout 5s;
+            proxy_buffering off;
+        }
+
+        # Control: the SSE exemption must not disable the WAF on the stream.
+        # Phase 1 still evaluates and still blocks -- what the exemption gives
+        # up is only the phase-4 clean-error-page path, not inspection itself.
+        location /guarded {
+            coraza on;
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess On
+                SecRule ARGS "@streq attack" "id:181,phase:1,status:403,deny,log"
+            ';
+            proxy_pass http://127.0.0.1:8081/events;
+            proxy_read_timeout 5s;
+            proxy_buffering off;
+        }
+    }
+}
+
+EOF
+
+$t->run_daemon(\&sse_daemon);
+$t->run()->waitforsocket('127.0.0.1:' . port(8081));
+
+###############################################################################
+
+# The SSE response headers and first events must reach the client promptly.
+# Previously they were delayed until a last_buf that never comes, so the
+# client saw nothing before the read timeout.
+my ($status, $body) = sse_read('/events');
+
+like($status, qr!HTTP/1\.1 200!, 'SSE response headers arrive');
+like($status, qr!text/event-stream!i, 'content-type is text/event-stream');
+like($body, qr/data: event-1/, 'first SSE event delivered');
+
+# Media-type variants that are still SSE must also skip the delay.
+($status, $body) = sse_read('/charset');
+like($body, qr/data: event-1/, 'SSE with "; charset=utf-8" delivered');
+
+($status, $body) = sse_read('/tab');
+like($body, qr/data: event-1/, 'SSE with HTAB OWS before ";" delivered');
+
+($status, $body) = sse_read('/mixedcase');
+like($body, qr/data: event-1/, 'SSE with mixed-case media type delivered');
+
+# Near-miss content types must NOT get the exemption: the phase-4 header
+# delay stays in force, so the client receives nothing early.
+($status, $body) = sse_read('/nearmiss', 2);
+is($status . $body, '', 'near-miss "text/event-streamx" stays delayed');
+
+($status, $body) = sse_read('/notsse', 2);
+is($status . $body, '', 'malformed "text/event-stream junk" stays delayed');
+
+# The exemption skips the header DELAY, not the WAF.  A phase-1 rule must
+# still block an SSE request, otherwise this change would be a bypass rather
+# than a streaming fix.
+($status, $body) = sse_read('/guarded?q=attack', 2);
+like($status, qr!HTTP/1\.1 403!, 'phase-1 rule still blocks an SSE request');
+
+# ...and a clean SSE request through the same guarded location still streams.
+($status, $body) = sse_read('/guarded?q=fine');
+like($body, qr/data: event-1/, 'guarded SSE location still streams when allowed');
+
+###############################################################################
+
+# Read the status line + whatever early body arrives, then bail without
+# waiting for the (never-ending) stream to close.
+sub sse_read {
+	my ($uri, $deadline) = @_;
+
+	$deadline ||= 4;
+
+	my $s = IO::Socket::INET->new(
+		Proto    => 'tcp',
+		PeerAddr => '127.0.0.1:' . port(8080),
+		Timeout  => 5,
+	) or return ('', '');
+
+	$s->print("GET $uri HTTP/1.1\r\n"
+		. "Host: localhost\r\n"
+		. "Connection: close\r\n\r\n");
+
+	my $buf = '';
+	eval {
+		local $SIG{ALRM} = sub { die "timeout\n" };
+		alarm($deadline);
+		# Stop as soon as we have headers plus the first event.
+		# sysread(): return as soon as any bytes arrive; read() would
+		# block for the full requested length, which a trickling stream
+		# never delivers.
+		while ($buf !~ /data: event-1/) {
+			my $chunk;
+			my $n = $s->sysread($chunk, 1024);
+			last if !defined $n || $n == 0;
+			$buf .= $chunk;
+		}
+		alarm(0);
+	};
+	alarm(0);
+	close($s);
+
+	my ($head, $body) = split /\r\n\r\n/, $buf, 2;
+	$head = '' unless defined $head;
+	$body = '' unless defined $body;
+	return ($head, $body);
+}
+
+sub sse_daemon {
+	my $server = IO::Socket::INET->new(
+		Proto     => 'tcp',
+		LocalHost => '127.0.0.1:' . port(8081),
+		Listen    => 5,
+		Reuse     => 1,
+	)
+		or die "Can't create listening socket: $!\n";
+
+	local $SIG{PIPE} = 'IGNORE';
+
+	my %ct = (
+		'/events'    => "text/event-stream",
+		'/charset'   => "text/event-stream; charset=utf-8",
+		'/tab'       => "text/event-stream\t; charset=utf-8",
+		'/mixedcase' => "Text/Event-Stream",
+		'/nearmiss'  => "text/event-streamx",
+		'/notsse'    => "text/event-stream junk",
+	);
+
+	while (my $client = $server->accept()) {
+		$client->autoflush(1);
+
+		my $uri = '/events';
+		my $headers = '';
+		while (<$client>) {
+			$uri = $1 if /^GET\s+(\S+)/;
+			$headers .= $_;
+			last if (/^\x0d?\x0a?$/);
+		}
+
+		my $type = $ct{$uri} || $ct{'/events'};
+
+		# Stream events with no Content-Length and never close on our own:
+		# a low-volume, never-terminating SSE endpoint.  The loop ends only
+		# when the client goes away (print to a dead socket fails), so the
+		# delayed-header path can never be rescued by an upstream close.
+		print $client "HTTP/1.1 200 OK\r\n"
+			. "Content-Type: $type\r\n"
+			. "Cache-Control: no-cache\r\n"
+			. "Connection: keep-alive\r\n\r\n";
+
+		my $i = 1;
+		while (print $client "data: event-$i\n\n") {
+			$i++;
+			select(undef, undef, undef, 0.2);
+		}
+
+		close $client;
+	}
+}
+
+###############################################################################


### PR DESCRIPTION
Fixes #81.

> [!IMPORTANT]
> **Depends on #73 — please merge that first.** This branch is based on #73
> because both touch the same delay condition in `ngx_http_coraza_header_filter()`.
> Merging this one first would conflict, and the SSE term must sit alongside
> `coraza_delay_response_headers`, not replace it. Once #73 lands I'll rebase
> onto `main` if the merge isn't clean.

## The problem

The connector delays response headers until phase-4 body inspection completes at
`last_buf`. An SSE stream emits events indefinitely and never sends a `last_buf`,
so the headers are held until the delayed-body cap (1 MiB) forces a flush.

The cap bounds *memory*, not *latency*. As the reporter measured on current `main`:

| endpoint | result |
|---|---|
| `/sse` (~14 B/s) | 0 bytes after 8 s, `time_starttransfer` never happens |
| `/sse?pad=131072` (~128 KiB/s) | first byte after ~7.1 s, once ≈1 MiB accumulated |

A real SSE endpoint (ArgoCD's application-event stream emits a few KiB per minute)
reaches 1 MiB after hours, so in practice the client receives nothing.

## The fix

Skip the header delay for `Content-Type: text/event-stream`, exactly as we already
do for `101 Switching Protocols`. The media-type match is strict: only
end-of-value, or optional OWS (SP/HTAB, RFC 9110 §5.6.3) followed by `;`, qualifies.
`text/event-streamx` and `text/event-stream junk` do **not** — they keep the delay.

## Security trade-off — please read

`Content-Type` is chosen by the upstream, so **an origin emitting
`text/event-stream` opts that response out of the phase-4 header delay.**

What is *not* affected:
- Phases 1–3 are untouched.
- Phase 4 still **runs** — the body filter always calls `coraza_process_response_body()`.

What is given up: the ability to turn a phase-4 match into a *clean error page*,
because the headers are already on the wire. A late match degrades to a connection
reset instead.

This is the same trade-off `101 Switching Protocols` already accepts, and it is
inherent — streaming and full-response WAF buffering are mutually exclusive by
construction. Flagging it explicitly so the choice is deliberate rather than
discovered later.

An alternative considered and rejected: gating on `ctx->response_body_processable`
(i.e. `SecResponseBodyAccess Off`) instead of the Content-Type. That reads like the
tidier fix — the delay condition's own comment already promises it — but it is
**wrong**: phase-4 rules keyed on non-body variables (`ARGS`, `TX`) fire regardless
of body inspection, and skipping the delay for them breaks their clean error page.
Verified: it fails 5 phase-4 cases in `coraza.t` with
`[alert] header already sent while sending response to client`.

If maintainers prefer the exemption to be opt-in rather than upstream-driven, the
natural follow-up is gating it behind the #73 directive — happy to do that instead.

## Tests

`t/coraza-sse.t` — the upstream daemon never closes the connection, so a delayed
response can never be rescued by an upstream-close flush.

Controls, so this can't silently regress into a bypass:
- near-miss media types must **stay** delayed;
- a phase-1 rule must still **block** an SSE request.

Verified locally against nginx 1.28.0 (ASan/UBSan):
- **with** the fix: 12/12 pass;
- **without** it: 7 fail, reproducing #81 exactly;
- full `coraza*.t`: no regressions — `coraza.t`'s phase-4 block/redirect cases stay green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-Sent Events responses now stream promptly without waiting for the connection to close.
  * SSE responses continue to undergo web application firewall inspection and enforcement.

* **Bug Fixes**
  * Improved media-type detection to avoid treating near-match content types as SSE responses.
  * Preserved request blocking behavior for protected SSE endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->