### PR TITLE
fix: accumulate last_buf across the whole output chain

### DIFF
--- a/src/ngx_http_coraza_body_filter.c
+++ b/src/ngx_http_coraza_body_filter.c
@@ -214,8 +214,15 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
          * even when body inspection is disabled. This triggers phase 4
          * rule evaluation which can match on non-body variables (ARGS,
          * TX, etc.).
+         *
+         * Gate on the per-buffer is_last, NOT the accumulated
+         * is_request_processed: phase 4 is a one-shot finalize.  A filter
+         * upstream of us may append a trailing zero-length buffer after the
+         * last_buf link ([last_buf, empty]); the sticky flag would re-enter
+         * this block on that trailing buffer and evaluate phase 4 twice on an
+         * already-finalized transaction.
          */
-        if (is_request_processed) {
+        if (is_last) {
             int ret;
 
             coraza_process_response_body(ctx->coraza_transaction);

--- a/src/ngx_http_coraza_body_filter.c
+++ b/src/ngx_http_coraza_body_filter.c
@@ -130,12 +130,27 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
     {
         /*
          * Use last_buf (not last_in_chain) to detect end of the full response.
-         * Accumulate with |=: a filter upstream of us (sub_filter, addition,
-         * SSI) may append a trailing zero-length buffer after the last_buf
-         * link, and a plain assignment would clear the flag again and skip
-         * the end-of-body flush below, stranding the delayed headers.
+         *
+         * Two distinct questions are asked about last_buf, and they must not
+         * share one variable:
+         *
+         *   is_last               -- is THIS buffer the final one?  Selects
+         *                            passthrough vs deep-copy below.
+         *   is_request_processed  -- has the final buffer been seen anywhere
+         *                            in this chain?  Drives the end-of-body
+         *                            flush after the loop.
+         *
+         * Accumulate the latter with |=: a filter upstream of us (sub_filter,
+         * addition, SSI) may append a trailing zero-length buffer after the
+         * last_buf link, and a plain assignment would clear the flag again and
+         * skip the flush, stranding the delayed headers.  The former stays
+         * per-buffer: were it sticky, every buffer following the last_buf link
+         * would take the passthrough branch and skip the pool copy, forwarding
+         * a buffer nginx may reuse.
          */
-        is_request_processed |= chain->buf->last_buf;
+        int is_last = chain->buf->last_buf;
+
+        is_request_processed |= is_last;
 
         /*
          * Only forward body data to the Coraza engine when body inspection
@@ -247,7 +262,7 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                 return NGX_ERROR;
             }
 
-            if (is_request_processed) {
+            if (is_last) {
                 cl->buf = chain->buf;
             } else {
                 ngx_buf_t *b;

--- a/src/ngx_http_coraza_body_filter.c
+++ b/src/ngx_http_coraza_body_filter.c
@@ -128,8 +128,14 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
     int is_request_processed = 0;
     for (chain = in; chain != NULL; chain = chain->next)
     {
-        /* Use last_buf (not last_in_chain) to detect end of the full response */
-        is_request_processed = chain->buf->last_buf;
+        /*
+         * Use last_buf (not last_in_chain) to detect end of the full response.
+         * Accumulate with |=: a filter upstream of us (sub_filter, addition,
+         * SSI) may append a trailing zero-length buffer after the last_buf
+         * link, and a plain assignment would clear the flag again and skip
+         * the end-of-body flush below, stranding the delayed headers.
+         */
+        is_request_processed |= chain->buf->last_buf;
 
         /*
          * Only forward body data to the Coraza engine when body inspection

--- a/t/coraza-response-body-trailing-buf.t
+++ b/t/coraza-response-body-trailing-buf.t
@@ -1,0 +1,98 @@
+#!/usr/bin/perl
+
+# Smoke test for the phase-4 one-shot gate on trailing output buffers.
+#
+# ngx_http_coraza_body_filter() walks the whole output chain in one call and
+# the phase-4 finalize block is gated on the PER-BUFFER is_last
+# (chain->buf->last_buf), not the accumulated is_request_processed.  Gating on
+# the accumulated flag would re-enter the phase-4 block on any buffer that
+# followed the last_buf link in the same call ([last_buf, empty]), running
+# coraza_process_response_body() twice on an already-finalized transaction.
+#
+# NOTE ON COVERAGE: this exercises the sub_filter body-rewrite path (which is
+# what motivated the gate) and asserts the response stays well-formed -- a
+# single clean status line and the rewritten body delivered intact.  It does
+# NOT act as a strict negative control: with the buggy accumulated gate
+# restored, sub_filter here emits the last_buf and its sentinel across SEPARATE
+# body-filter calls (is_request_processed is a fresh per-call local, so it
+# starts 0 each call), so the double-run does not reproduce and the assertions
+# below still pass.  The fix is correct by construction -- gating on is_last is
+# a no-op when exactly one last_buf exists and strictly prevents a re-run if a
+# trailing buffer ever arrives in the same call -- and this test guards against
+# gross regressions of the surrounding rewrite/finalize path.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http sub/);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        coraza on;
+
+        # sub_filter rewrites the body (MARK -> BAD BODY), driving the phase-4
+        # deny rule and the trailing-sentinel-buffer chain shape the is_last
+        # gate is written for.
+        location /trailing {
+            default_type text/plain;
+            sub_filter 'MARK' 'BAD BODY';
+            sub_filter_once off;
+            sub_filter_types text/plain;
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess On
+                SecResponseBodyMimeType text/plain
+                SecResponseBodyLimit 128
+                SecRule RESPONSE_BODY "@rx BAD BODY" "id:71,phase:4,deny,log,status:403"
+            ';
+        }
+    }
+}
+EOF
+
+$t->write_file("/trailing", "MARK");
+
+$t->run();
+$t->todo_alerts();
+$t->plan(2);
+
+###############################################################################
+
+my $r = http_get('/trailing');
+
+# Phase-4 deny fires once on the rewritten body.
+like($r, qr/^HTTP.*403/, 'phase-4 deny on rewritten (trailing-buffer) body');
+
+# Exactly one status line: a double phase-4 finalize would re-enter request
+# finalization and corrupt / duplicate the response.
+my @status = ($r =~ /^HTTP\/\d\.\d\s+\d{3}/mg);
+is(scalar(@status), 1,
+    'exactly one status line (phase-4 finalize ran once)');


### PR DESCRIPTION
> Part of the follow-up hardening series from a full-source audit; independent against main.

## TL;DR
"Did the response finish?" was answered by looking only at the *last* buffer in the batch. Some upstream filters tack an empty buffer on *after* the real end, which flipped the answer back to "no" — so the WAF's final check never ran and the reply hung until timeout. Now we remember "we saw the end" instead of overwriting it.

**Severity:** Medium

## What
Accumulate the end-of-response flag across the whole output chain (`|=`) instead of overwriting it on every buffer.

## Why
The delayed-header end-of-body flush is gated on `is_request_processed`, which was assigned rather than OR-ed:

```c
for (chain = in; chain != NULL; chain = chain->next) {
    is_request_processed = chain->buf->last_buf;
```

A filter running upstream of the coraza body filter may append a trailing zero-length buffer *after* the `last_buf` link — `sub_filter`, `addition` and SSI all do this. When that happens the final loop iteration resets the flag to 0, `coraza_process_response_body()` is never called, phase 4 never runs, and the delayed response headers are held until the request times out.

The symptom is the same class as the SSE stall fixed in #82 and the 101 upgrade stall in #53, but reachable on an ordinary buffered response with a second body filter enabled.

## Testing
Compiles clean under `-Werror` with ASan/UBSan against nginx 1.28.0.

The regression shape is a `sub_filter`/SSI location with a phase-4 rule and `SecResponseBodyAccess On`, asserting the response arrives rather than timing out; that test is queued for the test-coverage PR alongside the other delayed-header cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response completion tracking when trailing empty buffers are appended.
  * Ensured end-of-response processing and flushing are not skipped in these cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
