### PR TITLE
fix: always set intervention_triggered when an intervention fires

### DIFF
--- a/src/ngx_http_coraza_body_filter.c
+++ b/src/ngx_http_coraza_body_filter.c
@@ -170,8 +170,8 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 
             ret = ngx_http_coraza_process_intervention(ctx->coraza_transaction, r, 0);
             if (ret > 0) {
+                ctx->intervention_triggered = 1;
                 if (ctx->headers_delayed) {
-                    ctx->intervention_triggered = 1;
                     ctx->headers_delayed = 0;
                     return ret;
                 }
@@ -201,8 +201,8 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 
             ret = ngx_http_coraza_process_intervention(ctx->coraza_transaction, r, 0);
             if (ret > 0) {
+                ctx->intervention_triggered = 1;
                 if (ctx->headers_delayed) {
-                    ctx->intervention_triggered = 1;
                     ctx->headers_delayed = 0;
                     return ret;
                 }
@@ -210,8 +210,8 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                     &ngx_http_coraza_module, ret);
             }
             else if (ret < 0) {
+                ctx->intervention_triggered = 1;
                 if (ctx->headers_delayed) {
-                    ctx->intervention_triggered = 1;
                     ctx->headers_delayed = 0;
                     return NGX_HTTP_INTERNAL_SERVER_ERROR;
                 }


### PR DESCRIPTION
> Part of the follow-up hardening series from a full-source audit; independent against main.

## TL;DR
When the WAF blocked a response, it only wrote down "I already handled this" on one of the two exit paths. On the other path a later chunk walked back in and ran the WAF again on an already-finished job (a use-after-finalize). Now both paths write it down.

**Severity:** Medium

## What
Set `ctx->intervention_triggered` before the `ctx->headers_delayed` check at all three intervention sites in the body filter, so both the delayed and non-delayed paths record that an intervention fired.

## Why
`ctx->intervention_triggered` is the body filter's only re-entry guard:

```c
if (ctx->intervention_triggered) {
    return ngx_http_next_body_filter(r, in);
}
```

It was being set only inside the `ctx->headers_delayed` branch of each site. On the non-delayed path — headers already on the wire, i.e. after a cap flush, on an SSE stream, or after a 101 upgrade — the filter called `ngx_http_filter_finalize_request()` **without** recording that it had done so.

A subsequent buffer in the same output chain then re-entered the filter, passed the guard, and called `coraza_process_response_body()` and `ngx_http_coraza_process_intervention()` against an already-finalized transaction.

The `ret < 0` site inside the `response_body_processable` block already had the assignment hoisted correctly, so the file was internally inconsistent — three of the four sites were wrong.

## Testing
Compiles clean under `-Werror` with ASan/UBSan against nginx 1.28.0.

The observable failure is a use-after-finalize, so the durable guard is an ASan run over a multi-buffer response that takes a post-cap intervention; that is queued for the test-coverage PR, which adds the ASan job this needs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response handling when an intervention is triggered during body inspection.
  * Ensured intervention status is consistently recorded, including when response headers are delayed.
  * Preserved existing error handling for failed intervention processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
