### PR TITLE
fix: keep transaction_id length consistent on allocation failure

### DIFF
--- a/src/ngx_http_coraza_module.c
+++ b/src/ngx_http_coraza_module.c
@@ -186,8 +186,17 @@ ngx_http_coraza_create_ctx(ngx_http_request_t *r)
 			return NULL;
 		}
 		ctx->coraza_transaction = coraza_new_transaction_with_id(waf, (char *)s.data);
+
+		/*
+		 * Keep transaction_id.len consistent with .data: on allocation
+		 * failure leave the id empty rather than pairing a NULL pointer
+		 * with a non-zero length.  The engine already has the id (it was
+		 * passed to coraza_new_transaction_with_id above); this copy only
+		 * feeds the "%V" in the access-denied log line, which is guarded
+		 * on .len > 0.
+		 */
 		ctx->transaction_id.data = ngx_pstrdup(r->pool, &s);
-		ctx->transaction_id.len = s.len;
+		ctx->transaction_id.len = ctx->transaction_id.data ? s.len : 0;
 	}
 	else
 	{


### PR DESCRIPTION
> Part of the follow-up hardening series from a full-source audit; independent against main.

## TL;DR
On an out-of-memory hiccup the transaction-id ended up as "empty pointer, non-zero length" — and the log line trusted the length and read the empty pointer, risking a crash. Now the length is set to match: no id present, nothing read.

**Severity:** Low

## What
Assign `ctx->transaction_id.len` from the result of `ngx_pstrdup` so the pointer and the length stay consistent when the allocation fails.

## Why
`ngx_http_coraza_create_ctx` stored the copy unchecked and set the length unconditionally:

```c
ctx->transaction_id.data = ngx_pstrdup(r->pool, &s);
ctx->transaction_id.len = s.len;
```

On allocation failure that leaves `.data == NULL` paired with a non-zero `.len`. The access-denied log line in `ngx_http_coraza_process_intervention` formats exactly that pair with `"%V"`:

```c
if (ctx->transaction_id.len > 0) {
    ngx_log_error(..., "Coraza: Access denied with code %d, unique_id \"%V\"",
        intervention->status, &ctx->transaction_id);
}
```

The guard tests `.len` only, so `%V` dereferences the NULL `.data`.

Deriving `.len` from the result treats the id as simply absent instead. Returning `NULL` here was the alternative, but the cleanup handler is not registered until further down the function, so an early return would leak the transaction that was just created — a worse trade for a path that only feeds a log line. The engine already received the id via `coraza_new_transaction_with_id()`; this copy exists solely for that message.

## Testing
Compiles clean under `-Werror` with ASan/UBSan against nginx 1.28.0.

The failure needs pool-allocation fault injection to reach, so there is no `t/` test; the change is a consistency fix on an error path that is unreachable under normal load.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of configured transaction IDs when memory allocation fails.
  * Prevented invalid transaction ID data from appearing in access-denied log messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
