### PR TITLE
build: track common.h in the dynamic build's deps

### DIFF
--- a/config
+++ b/config
@@ -34,7 +34,8 @@ if test -n "$ngx_module_link"; then
                      $ngx_addon_dir/src/ngx_http_coraza_utils.c \
                      $ngx_addon_dir/src/ngx_http_coraza_dl.c";
 
-	ngx_module_deps="$ngx_addon_dir/src/ddebug.h";
+	ngx_module_deps="$ngx_addon_dir/src/ddebug.h \
+                     $ngx_addon_dir/src/ngx_http_coraza_common.h";
     ngx_module_libs="-ldl"
 
     ngx_module_order="ngx_http_chunked_filter_module \
@@ -52,6 +53,12 @@ else
 	CORE_INCS="$CORE_INCS $ngx_feature_path"
 	CORE_LIBS="$CORE_LIBS $ngx_feature_libs"
 
+	# Appending here places the coraza filter immediately before
+	# ngx_http_copy_filter_module in objs/ngx_modules.c, i.e. after the
+	# chunked/range/postpone filters -- the same effective position the
+	# dynamic build gets from $ngx_module_order above.  $ngx_module_order
+	# has no effect on this branch (it is only consumed by auto/module),
+	# so the ordering here is positional and must not be reordered.
 	HTTP_FILTER_MODULES="$HTTP_FILTER_MODULES ngx_http_coraza_module"
 	NGX_ADDON_SRCS="$NGX_ADDON_SRCS \
                     $ngx_addon_dir/src/ngx_http_coraza_module.c \


### PR DESCRIPTION
> Part of the follow-up hardening series from a full-source audit; independent against main.

## TL;DR
The build didn't know that the shared header file mattered, so editing it wouldn't trigger a rebuild — you could end up running stale object files against a changed struct. Now the header is a tracked dependency (and a confusing bit of build ordering is documented).

**Severity:** Low

## What
Add `ngx_http_coraza_common.h` to `ngx_module_deps` in the dynamic-build branch of `config`, and document why the static branch's `HTTP_FILTER_MODULES` append is position-sensitive.

## Why
The dynamic branch listed only `ddebug.h` as a dependency:

```sh
ngx_module_deps="$ngx_addon_dir/src/ddebug.h";
```

Every source file in the connector includes `ngx_http_coraza_common.h`, and it carries the ctx struct and `NGX_HTTP_CORAZA_MAX_DELAYED_BODY`. Editing it did not trigger a rebuild of the dynamic module, so a header change could leave stale objects linked against a changed struct layout — a stale-build hazard that surfaces as inexplicable runtime behaviour. The static branch's `NGX_ADDON_DEPS` already listed both headers; this brings the two into line.

The comment on the static branch records something non-obvious I confirmed while checking a suspected ordering divergence: `ngx_module_order` is consumed only by `auto/module` and has **no effect** on the static branch, so that branch's filter position comes purely from where the append lands. I verified by configuring a static build both before and after this change and diffing `objs/ngx_modules.c`: the coraza filter sits immediately before `ngx_http_copy_filter_module` in both, i.e. the existing position already matches the dynamic build's `ngx_module_order`. No ordering change was needed — but nothing in the file said so, and the next person to look at the asymmetry would have to re-derive it.

## Testing
Verified both build modes configure and compile clean against nginx 1.28.0, and that `ADDON_DEPS` in the generated `objs/Makefile` now lists `ngx_http_coraza_common.h` in each.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build configuration to include a required source header dependency.
  * Clarified module ordering behavior for alternate build configurations, supporting more reliable builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
