### PR TITLE
chore: drop the unused ngx_http_coraza_log callback

### DIFF
--- a/src/ngx_http_coraza_common.h
+++ b/src/ngx_http_coraza_common.h
@@ -157,7 +157,6 @@ ngx_int_t ngx_http_coraza_header_filter(ngx_http_request_t *r);
 ngx_int_t ngx_http_coraza_forward_header(ngx_http_request_t *r);
 
 /* ngx_http_coraza_log.c */
-void ngx_http_coraza_log(void *log, const void* data);
 ngx_int_t ngx_http_coraza_log_handler(ngx_http_request_t *r);
 
 /* ngx_http_coraza_pre_access.c */

--- a/src/ngx_http_coraza_log.c
+++ b/src/ngx_http_coraza_log.c
@@ -12,13 +12,6 @@
 #include "ngx_http_coraza_common.h"
 
 
-void
-ngx_http_coraza_log(void *log, const void* data)
-{
-    ngx_log_error(NGX_LOG_INFO, (ngx_log_t *)log, 0, "%s", (const char *)data);
-}
-
-
 ngx_int_t
 ngx_http_coraza_log_handler(ngx_http_request_t *r)
 {


### PR DESCRIPTION
> Part of the follow-up hardening series from a full-source audit; independent against main.

## TL;DR
A leftover log helper from the ModSecurity port that nothing calls, and whose loose `void *` casts would silently mis-wire to a future callback. Deleted so the next person writes the cast against the real signature.

**Severity:** Low

## What
Remove `ngx_http_coraza_log()` and its prototype.

## Why
The function was defined in `ngx_http_coraza_log.c` and declared in `ngx_http_coraza_common.h`, but is never referenced: there is no `coraza_set_log_cb` (or equivalent) call anywhere in the connector, and nothing else calls it. It is dead code.

It is also a shape worth not leaving lying around:

```c
void
ngx_http_coraza_log(void *log, const void* data)
{
    ngx_log_error(NGX_LOG_INFO, (ngx_log_t *)log, 0, "%s", (const char *)data);
}
```

Both parameters are `void *` and both are cast without checking — `log` to `ngx_log_t *`, `data` to a NUL-terminated C string. Wiring this to a future libcoraza callback whose signature differs would compile silently and fail at runtime as type confusion, rather than failing at the call site. Deleting it means the next person wiring up a log callback writes the cast deliberately against the real signature.

Audit logging is unaffected: that path runs through `ngx_http_coraza_log_handler()` and `coraza_process_logging()`, both of which are untouched.

## Testing
Compiles clean under `-Werror` with ASan/UBSan against nginx 1.28.0. No behaviour change — the removed function had no callers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined request logging by removing an obsolete logging callback.
  * Standardized the logging interface around request-scoped handling.
  * Existing logging behavior remains available when logging is enabled and applicable to the request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
