### PR TITLE
docs: correct the is_response_body_processable fallback contract

### DIFF
--- a/src/ngx_http_coraza_dl.c
+++ b/src/ngx_http_coraza_dl.c
@@ -320,7 +320,12 @@ int coraza_update_status_code(coraza_transaction_t t, int code)
  * SecResponseBodyMimeType).  Must be called after
  * coraza_process_response_headers().
  *
- * Requires libcoraza >= 1.4.0.
+ * Requires libcoraza >= 1.4.0.  The symbol is resolved with the mandatory
+ * DL_SYM in ngx_http_coraza_dl_open(), so dl_is_response_body_processable is
+ * guaranteed non-NULL here: if the running library did not export it, dl_open
+ * failed and the worker never started.  No NULL guard is needed (and none must
+ * be relied upon) -- if this symbol is ever downgraded to DL_SYM_OPT, this
+ * wrapper and its callers must add an availability check first.
  */
 int
 ngx_http_coraza_is_response_body_processable(coraza_transaction_t t)

--- a/src/ngx_http_coraza_header_filter.c
+++ b/src/ngx_http_coraza_header_filter.c
@@ -479,11 +479,16 @@ ngx_http_coraza_header_filter(ngx_http_request_t *r)
      * first so the library can evaluate SecResponseBodyAccess and the
      * Content-Type against SecResponseBodyMimeType.
      *
-     * With libcoraza 1.4+ the library answers this directly:
+     * The library answers this directly:
      *   - SecResponseBodyAccess Off  → 0 (no inspection needed)
      *   - Content-Type not in SecResponseBodyMimeType → 0
      *   - Otherwise → 1
-     * With older libcoraza the helper always returns 1 (conservative).
+     *
+     * coraza_is_response_body_processable is a required symbol (libcoraza
+     * >= 1.4.0, pinned in debian/control) resolved with the mandatory DL_SYM:
+     * a library that does not export it fails ngx_http_coraza_dl_open() and the
+     * worker never starts, so there is no runtime "old library" fallback here
+     * and the pointer is never NULL by the time this runs.
      */
     ctx->response_body_processable =
         ngx_http_coraza_is_response_body_processable(ctx->coraza_transaction);


### PR DESCRIPTION
> Part of the follow-up hardening series from a full-source audit; independent against main.

## TL;DR
A comment claimed there's a safe fallback for old libcoraza that lacks this symbol — but there isn't: the symbol is a hard requirement and the worker won't even start without it. The comment is a trap: someone trusting it could later introduce a crash. Fixed the comment to state the real contract.

**Severity:** Low (documentation / latent trap — no runtime behavior change)

## What
The header filter and the `ngx_http_coraza_is_response_body_processable` wrapper claim that "with older libcoraza the helper always returns 1 (conservative)", implying a runtime fallback for a library that does not export the symbol.

## Why it's wrong
`coraza_is_response_body_processable` is resolved with the **mandatory** `DL_SYM` in `ngx_http_coraza_dl_open()`, not `DL_SYM_OPT`. A library missing the symbol fails `dl_open()` and the worker never starts (and `debian/control` pins `libcoraza1 (>= 1.4.0)`). So:

- there is no "older libcoraza" fallback path — the comment describes code that does not exist;
- `dl_is_response_body_processable` is guaranteed non-NULL by the time the wrapper runs, so the unguarded call is correct — but only because of the hard resolve.

The risk is latent: anyone who later flips this symbol to `DL_SYM_OPT` (as the bulk-header symbols already are) would turn the unguarded wrapper into a NULL deref, guided by a comment that says a fallback exists.

## Change
Comments only. State the real contract (required symbol, hard resolve, never NULL here) and flag that a future `DL_SYM_OPT` downgrade must add an availability check first — mirroring how the bulk-header entry points are already gated by `ngx_http_coraza_bulk_headers_available()`. No code behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified requirements for response-body processing support.
  * Documented that missing required functionality prevents the worker from starting, improving clarity around startup compatibility and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->