### PR TITLE
fix: validate transaction handle and transaction_id copy in create_ctx

### DIFF
--- a/src/ngx_http_coraza_module.c
+++ b/src/ngx_http_coraza_module.c
@@ -186,19 +186,33 @@ ngx_http_coraza_create_ctx(ngx_http_request_t *r)
 			return NULL;
 		}
 		ctx->coraza_transaction = coraza_new_transaction_with_id(waf, (char *)s.data);
-		ctx->transaction_id.data = ngx_pstrdup(r->pool, &s);
-		ctx->transaction_id.len = s.len;
 	}
 	else
 	{
 		ctx->coraza_transaction = coraza_new_transaction(waf);
-		ngx_str_null(&ctx->transaction_id);
+		ngx_str_null(&s);
+	}
+
+	/*
+	 * Validate the transaction handle before use. A NULL handle would make
+	 * every subsequent coraza_process and coraza_add call inspect nothing
+	 * (fail-open) and would be passed on to coraza_free_transaction() in the
+	 * cleanup. Fail closed instead: the caller turns a NULL ctx into a 500.
+	 */
+	if (ctx->coraza_transaction == 0)
+	{
+		dd("failed to create the CORAZA transaction");
+		return NULL;
 	}
 
 	dd("transaction created");
 
 	ngx_http_set_ctx(r, ctx, ngx_http_coraza_module);
 
+	/*
+	 * Register the cleanup now that the transaction exists, so that any
+	 * failure below (e.g. the ngx_pstrdup) still frees the transaction.
+	 */
 	cln = ngx_pool_cleanup_add(r->pool, 0);
 	if (cln == NULL)
 	{
@@ -207,6 +221,20 @@ ngx_http_coraza_create_ctx(ngx_http_request_t *r)
 	}
 	cln->handler = ngx_http_coraza_cleanup;
 	cln->data = ctx;
+
+	if (mcf->transaction_id)
+	{
+		ctx->transaction_id.data = ngx_pstrdup(r->pool, &s);
+		if (ctx->transaction_id.data == NULL)
+		{
+			return NULL;
+		}
+		ctx->transaction_id.len = s.len;
+	}
+	else
+	{
+		ngx_str_null(&ctx->transaction_id);
+	}
 
 	return ctx;
 }

--- a/src/ngx_http_coraza_module.c
+++ b/src/ngx_http_coraza_module.c
@@ -217,6 +217,8 @@ ngx_http_coraza_create_ctx(ngx_http_request_t *r)
 	if (cln == NULL)
 	{
 		dd("failed to create the CORAZA context cleanup");
+		(void) coraza_free_transaction(ctx->coraza_transaction);
+		ctx->coraza_transaction = 0;
 		return NULL;
 	}
 	cln->handler = ngx_http_coraza_cleanup;


### PR DESCRIPTION
> Part of the follow-up hardening series from a full-source audit; independent against main.

## TL;DR
Before letting a bouncer (the WAF) inspect a guest, we hire the bouncer, jot down their ID, and leave a note to fire them when the party ends. The old code never checked the bouncer actually showed up (so nobody got inspected), could copy a blank ID and later read it as if it had text (crash), and wrote the "fire them" note *after* things could already go wrong (bouncer left on the clock forever = leak). Now: hire → confirm they showed → leave the fire-note → copy the ID, checking each step.

**Severity:** Medium (fail-open inspection + a remotely-triggerable worker crash, both under pool pressure)

## What
`ngx_http_coraza_create_ctx()` had three related lifecycle gaps in transaction setup, all fixed at the one site (`ngx_http_coraza_module.c`):

1. **Unchecked transaction handle** — `coraza_new_transaction[_with_id]()`'s return was never validated.
2. **Unchecked `transaction_id` copy** — `ngx_pstrdup()` for `transaction_id.data` was unchecked while `transaction_id.len` was set unconditionally.
3. **Late cleanup registration** — the transaction was created *before* `ngx_pool_cleanup_add()`.

## Why that's a problem
1. A NULL/0 handle is stored in the ctx and then passed to every `coraza_process_*` / `coraza_add_*` call for the request — each **inspecting nothing = fail-open** — and finally to `coraza_free_transaction()` in the pool cleanup.
2. On pool exhaustion the copy leaves `data == NULL, len > 0`. On the next denied request `ngx_http_coraza_process_intervention()` logs it with `%V`, copying `len` bytes from a NULL pointer → **worker crash** (needs `coraza_transaction_id` configured + an intervention to fire).
3. If `ngx_pool_cleanup_add()` (or the pstrdup) failed after the transaction existed, the Go-side transaction **leaked**.

## Fix
- Validate the handle right after creation; a failed create returns NULL, which the caller turns into a **500 (fail-closed)**.
- Register the cleanup immediately after the handle is validated, so every later failure path still frees the transaction.
- Check the `transaction_id` copy and set `.len` only on success.

No behaviour change on the success path.

## Testing
Existing `t/*.t` suite covers the fail-closed 500 path via the config-error tests. The NULL-deref crash path requires allocation-failure injection, so it has no black-box negative control; the fix removes the unchecked pointer rather than adding a reachable branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when starting a new transaction: requests now stop safely instead of continuing with an invalid transaction handle.
  * Added safer handling for transaction ID initialization, including graceful failure if required resources can’t be allocated.
  * Ensured transaction cleanup is registered promptly after successful creation, so cleanup occurs reliably even if later initialization steps fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->