### PR TITLE
fix: fail closed when request-body submission to Coraza fails

### DIFF
--- a/src/ngx_http_coraza_pre_access.c
+++ b/src/ngx_http_coraza_pre_access.c
@@ -137,12 +137,14 @@ ngx_http_coraza_pre_access_handler(ngx_http_request_t *r)
             dd("request body inspection: file -- %s", file_name);
 
             /*
-             * A negative return means libcoraza could not read/submit the
+             * A non-zero return means libcoraza could not read/submit the
              * body file, so the engine would evaluate phase 2 against no (or
              * a partial) body while nginx forwards the full body upstream.
              * Fail closed rather than inspect less than we forward.
+             * (libcoraza signals failure with a positive sentinel, so test
+             * != 0, not < 0.)
              */
-            if (coraza_request_body_from_file(ctx->coraza_transaction, file_name) < 0) {
+            if (coraza_request_body_from_file(ctx->coraza_transaction, file_name) != 0) {
                 ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                     "coraza: failed to submit file-buffered request body for inspection");
                 ctx->intervention_triggered = 1;
@@ -172,11 +174,13 @@ ngx_http_coraza_pre_access_handler(ngx_http_request_t *r)
             }
 
             /*
-             * A negative return means the chunk was not appended, so the
+             * A non-zero return means the chunk was not appended, so the
              * engine would inspect a shorter body than nginx forwards
              * upstream (a request-smuggling-style bypass). Fail closed.
+             * (libcoraza signals failure with a positive sentinel, so test
+             * != 0, not < 0.)
              */
-            if (coraza_append_request_body(ctx->coraza_transaction, data, blen) < 0) {
+            if (coraza_append_request_body(ctx->coraza_transaction, data, blen) != 0) {
                 ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                     "coraza: failed to append request body chunk for inspection");
                 ctx->intervention_triggered = 1;

--- a/src/ngx_http_coraza_pre_access.c
+++ b/src/ngx_http_coraza_pre_access.c
@@ -136,7 +136,18 @@ ngx_http_coraza_pre_access_handler(ngx_http_request_t *r)
              */
             dd("request body inspection: file -- %s", file_name);
 
-            coraza_request_body_from_file(ctx->coraza_transaction, file_name);
+            /*
+             * A negative return means libcoraza could not read/submit the
+             * body file, so the engine would evaluate phase 2 against no (or
+             * a partial) body while nginx forwards the full body upstream.
+             * Fail closed rather than inspect less than we forward.
+             */
+            if (coraza_request_body_from_file(ctx->coraza_transaction, file_name) < 0) {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                    "coraza: failed to submit file-buffered request body for inspection");
+                ctx->intervention_triggered = 1;
+                return NGX_HTTP_INTERNAL_SERVER_ERROR;
+            }
 
             already_inspected = 1;
         } else {
@@ -160,7 +171,17 @@ ngx_http_coraza_pre_access_handler(ngx_http_request_t *r)
                 return NGX_HTTP_INTERNAL_SERVER_ERROR;
             }
 
-            coraza_append_request_body(ctx->coraza_transaction, data, blen);
+            /*
+             * A negative return means the chunk was not appended, so the
+             * engine would inspect a shorter body than nginx forwards
+             * upstream (a request-smuggling-style bypass). Fail closed.
+             */
+            if (coraza_append_request_body(ctx->coraza_transaction, data, blen) < 0) {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                    "coraza: failed to append request body chunk for inspection");
+                ctx->intervention_triggered = 1;
+                return NGX_HTTP_INTERNAL_SERVER_ERROR;
+            }
 
             if (chain->buf->last_buf) {
                 break;


### PR DESCRIPTION
> Part of the follow-up hardening series from a full-source audit; independent against main.

## TL;DR
nginx forwards the whole letter to the backend, but the security scanner only got to read half of it and said "couldn't finish." The old code shrugged and sent the letter anyway. An attacker could hide the nasty part in the half the scanner never saw. Now: if the scanner can't read the whole thing, we refuse the letter.

**Severity:** Medium (request-body inspection bypass — a request-smuggling-style evasion)

## What
Both request-body submission paths in the pre-access handler discarded the `int` returned by libcoraza (`ngx_http_coraza_pre_access.c`):

- `coraza_append_request_body()` — in-memory chunk path
- `coraza_request_body_from_file()` — temp-file path (previously had **no** failure handling at all)

## Why that's a problem
A failure return means the body (or a chunk) was **not** submitted to the engine, so phase-2 rules run against a **shorter body than nginx forwards upstream** — a request-smuggling-style inspection bypass. The post-append intervention poll only catches an actual interruption, not a submission failure, so the miss was silent (**fail-open**).

## Fix
Both calls now check the return and **fail closed** (500), matching how the header path already checks `coraza_add_request_header`.

> **Reviewer note (polarity):** this PR tests `< 0`. The libcoraza C export signals an append/file error with a **positive** sentinel (`return 1`), so a `< 0` test never fires — the guard should be `!= 0` to actually fail closed. See the response-side twin #100, which uses `!= 0`, and the inline comment on this PR. Recommend switching to `!= 0` before merge.

## Testing
Existing `t/coraza-request-body*.t` cover the success path. The failure path requires a libcoraza-side append error (fault injection), so there is no black-box negative control.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved request processing reliability by treating security inspection failures as errors instead of allowing requests to continue.
  - Requests that cannot be inspected correctly are now rejected with an internal server error, helping prevent unvalidated traffic from proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->