### PR TITLE
fix: fail closed on NGX_ERROR from the intervention handler

### DIFF
--- a/src/ngx_http_coraza_pre_access.c
+++ b/src/ngx_http_coraza_pre_access.c
@@ -195,6 +195,11 @@ ngx_http_coraza_pre_access_handler(ngx_http_request_t *r)
 
             /* Check for intervention after each chunk for prompt detection */
             ret = ngx_http_coraza_process_intervention(ctx, r, 0);
+            if (ret < 0) {
+                /* NGX_ERROR from the intervention handler: fail closed. */
+                ctx->intervention_triggered = 1;
+                return NGX_HTTP_INTERNAL_SERVER_ERROR;
+            }
             if (ret > 0) {
                 ctx->intervention_triggered = 1;
                 return ret;
@@ -212,6 +217,11 @@ ngx_http_coraza_pre_access_handler(ngx_http_request_t *r)
         ret = ngx_http_coraza_process_intervention(ctx, r, 0);
         if (r->error_page) {
             return NGX_DECLINED;
+        }
+        if (ret < 0) {
+            /* NGX_ERROR from the intervention handler: fail closed. */
+            ctx->intervention_triggered = 1;
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
         }
         if (ret > 0) {
             ctx->intervention_triggered = 1;
@@ -235,6 +245,11 @@ ngx_http_coraza_pre_access_handler(ngx_http_request_t *r)
         ret = ngx_http_coraza_poll_after_process(ctx, r, 0, pret);
         if (r->error_page) {
             return NGX_DECLINED;
+        }
+        if (ret < 0) {
+            /* NGX_ERROR from the intervention handler: fail closed. */
+            ctx->intervention_triggered = 1;
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
         }
         if (ret > 0) {
             ctx->intervention_triggered = 1;

--- a/src/ngx_http_coraza_rewrite.c
+++ b/src/ngx_http_coraza_rewrite.c
@@ -315,6 +315,11 @@ ngx_http_coraza_rewrite_handler(ngx_http_request_t *r)
         if (r->error_page) {
             return NGX_DECLINED;
             }
+        if (ret < 0) {
+            /* NGX_ERROR from the intervention handler: fail closed. */
+            ctx->intervention_triggered = 1;
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        }
         if (ret > 0) {
             ctx->intervention_triggered = 1;
             return ret;


### PR DESCRIPTION
> Part of the follow-up hardening series from a full-source audit; independent against main. Rebased onto main after #92 reworked `pre_access.c`.

## TL;DR
The scanner can answer "fine," "block it," or "something broke." Two phases listened for "block it" but treated "something broke" as "fine." Nothing currently makes it say "something broke" there, but if that ever changes the request would sail through. Now "something broke" = refuse.

**Severity:** Low (latent / defense-in-depth — **not presently exploitable**)

## What
The rewrite and pre-access phase handlers tested the intervention return with only `if (ret > 0)`, so a negative `NGX_ERROR` fell through the same as `NGX_OK` (continue). Only the body filter checked both signs. Four call sites across `ngx_http_coraza_rewrite.c` and `ngx_http_coraza_pre_access.c`.

Since #92 the polls take two forms, and both carry the same return contract:

* `ngx_http_coraza_process_intervention(ctx, r, early_log)` — three sites in `ngx_http_coraza_pre_access.c`
* `ngx_http_coraza_poll_after_process(ctx, r, early_log, pret)` — one site in `ngx_http_coraza_rewrite.c`, after `coraza_process_request_headers()`

`ngx_http_coraza_common.h` states the second is a pass-through on this point: it "returns NGX_OK / >0 status / NGX_ERROR exactly as that helper does, so callers keep their existing error_page and ret handling." So the missing `ret < 0` arm is the same gap on both.

## Why that's a problem
Treating `NGX_ERROR` as "continue" is **fail-open**. `ngx_http_coraza_process_intervention()` currently returns `NGX_ERROR` only when `r->header_sent` is already true, which cannot happen in these two request phases — so this is **not presently reachable**. It is latent: any future `NGX_ERROR` path added to the intervention contract would be silently ignored at these sites.

## Fix
Handle `ret < 0` as a fail-closed 500 at all four call sites, matching the body filter. No behaviour change on any currently reachable path — contract-consistency / defense-in-depth.

The original branch guarded six sites. Two of them were the `rewrite.c` polls after `coraza_process_connection()` and `coraza_process_uri()`, which #92 removed as provably-nil — neither call runs a rule phase, so `tx.Interruption()` cannot be set yet. Re-adding an error arm there would have meant restoring the CGO crossings #92 deleted, so those two are dropped rather than ported. The remaining four are the sites where a poll still happens.

## Testing
No new runtime test: the `NGX_ERROR` branch is structurally unreachable in these phases today, so it has no black-box negative control. The change makes the four sites match the already-tested body-filter contract; existing `t/*.t` confirm no regression on the reachable paths.

Post-rebase verification:

* builds clean against nginx 1.29.0 with the addon's `-Werror` flags
* `git merge-tree` confirms no conflict with #99, so either merge order works
* CI green on the rebased head: Build&Test, A/UBSan, Valgrind, CodeQL, Fuzzing, Security Scanners
