### PR TITLE
chore: remove dead ngx_http_coraza_log()

### DIFF
--- a/src/ngx_http_coraza_common.h
+++ b/src/ngx_http_coraza_common.h
@@ -158,7 +158,6 @@ ngx_int_t ngx_http_coraza_header_filter(ngx_http_request_t *r);
 ngx_int_t ngx_http_coraza_forward_header(ngx_http_request_t *r);
 
 /* ngx_http_coraza_log.c */
-void ngx_http_coraza_log(void *log, const void* data);
 ngx_int_t ngx_http_coraza_log_handler(ngx_http_request_t *r);
 
 /* ngx_http_coraza_pre_access.c */

--- a/src/ngx_http_coraza_log.c
+++ b/src/ngx_http_coraza_log.c
@@ -12,13 +12,6 @@
 #include "ngx_http_coraza_common.h"
 
 
-void
-ngx_http_coraza_log(void *log, const void* data)
-{
-    ngx_log_error(NGX_LOG_INFO, (ngx_log_t *)log, 0, "%s", (const char *)data);
-}
-
-
 ngx_int_t
 ngx_http_coraza_log_handler(ngx_http_request_t *r)
 {


### PR DESCRIPTION
> Part of the follow-up hardening series from a full-source audit; independent against main.

## TL;DR
An old tool in the drawer that no machine is plugged into. Threw it out. Nothing else moves.

**Severity:** None (dead-code removal, no behaviour change)

## What
`ngx_http_coraza_log(void *log, const void *data)` in `ngx_http_coraza_log.c`, plus its prototype in `ngx_http_coraza_common.h`.

## Why that's a problem
It has **no callers** — the wired audit-log path uses `ngx_http_coraza_log_handler()`, a different function. It is leftover from the ModSecurity connector port and is dead surface that reads as live.

## Fix
Remove the definition and the prototype. No behaviour change.

## Testing
Removal only; the whole `t/*.t` suite still builds and passes with the symbol gone (no reference existed to break).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request logging integration by using the request-scoped logging handler.
  * Removed an unused logging pathway, helping ensure consistent and reliable request log processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->