### PR TITLE
fix: fail closed when response-body submission to Coraza fails

### DIFF
--- a/src/ngx_http_coraza_body_filter.c
+++ b/src/ngx_http_coraza_body_filter.c
@@ -165,7 +165,30 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
             }
 
             if (len > 0) {
-                coraza_append_response_body(ctx->coraza_transaction, data, len);
+                /*
+                 * A non-zero return means libcoraza could not write the
+                 * chunk into the response-body buffer, so the engine would
+                 * evaluate phase 4 against a shorter body than nginx streams
+                 * to the client -- an inspection bypass. Fail closed, exactly
+                 * as the request-body append path does. Matches the libcoraza
+                 * contract where coraza_append_response_body() returns 1 on a
+                 * WriteResponseBody error and 0 on success.
+                 */
+                if (coraza_append_response_body(ctx->coraza_transaction,
+                                                data, len) != 0)
+                {
+                    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                        "coraza: failed to append response body chunk "
+                        "for inspection");
+                    ctx->intervention_triggered = 1;
+                    if (ctx->headers_delayed) {
+                        ctx->headers_delayed = 0;
+                        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+                    }
+                    return ngx_http_filter_finalize_request(r,
+                        &ngx_http_coraza_module,
+                        NGX_HTTP_INTERNAL_SERVER_ERROR);
+                }
             }
 
             ret = ngx_http_coraza_process_intervention(ctx->coraza_transaction, r, 0);


### PR DESCRIPTION
> Part of the follow-up hardening series from a full-source audit; independent against main. Response-side twin of #96.

## TL;DR
On the way *out*, the scanner tried to read the reply and said "couldn't finish buffering it." The old code sent the reply to the visitor anyway, so anything hidden in the unread part slipped past. Now: if the scanner can't hold the whole reply to check it, we don't send it.

**Severity:** Medium (response-body inspection bypass — fail-open)

## What
The response body filter discarded the return value of `coraza_append_response_body()` (`ngx_http_coraza_body_filter.c`). Per the libcoraza contract that call returns non-zero (`1`) when `tx.WriteResponseBody()` fails, and `0` on success:

```go
//export coraza_append_response_body
func coraza_append_response_body(t C.coraza_transaction_t, data *C.uchar, length C.int) C.int {
    tx := fromRaw[types.Transaction](t)
    if _, _, err := tx.WriteResponseBody(...); err != nil {
        return 1
    }
    return 0
}
```

## Why that's a problem
On a write failure the chunk is not buffered inside the engine, so phase 4 is evaluated against a **shorter body than nginx streams to the client** — a response-body inspection bypass. The intervention poll that follows does not catch it: a write error is not an interruption, so the miss was silent (**fail-open**). This is the response-side twin of the request-body append path, which already fails closed (#96).

## Fix
- Check the return of `coraza_append_response_body()` and **fail closed** with 500 on a non-zero result.
- Honour the `headers_delayed` state exactly as the surrounding intervention branches in the same filter do.
- Uses `!= 0` (not `< 0`): the Go export signals the error with `1`, so a `< 0` test would never fire.

## Testing
Narrow, defensive check on an error path not reachable in normal operation (`WriteResponseBody` only errors on an internal buffer failure), so there is no black-box Test::Nginx negative control for it. The existing `t/coraza-response-body*.t` confirm no regression on the success path; CI (compile, sanitizer, fuzz, config-lint, debug build) is green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of response-body inspection failures.
  * Requests now terminate with an internal server error when response processing cannot be completed, preventing potentially invalid responses from continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->