### PR TITLE
fix: fail closed when body-phase processing fails in Coraza

### DIFF
--- a/config
+++ b/config
@@ -19,22 +19,24 @@ ngx_addon_name="ngx_http_coraza_module"
 # 0 on success, so "failed" means `ret != 0`.
 #
 # CORAZA_INTERRUPTION is an *enum member*, not a #define, so it is invisible to
-# the preprocessor and cannot be tested with `#ifdef` in the C sources.  Grep
-# the installed header here and pass -DCORAZA_HAS_RESULT_ENUM so the connector
-# can select the correct contract.  ngx_http_coraza_process_body_failed() reads
-# this macro.
-coraza_result_hdr=""
-for _d in /usr/local/include /usr/include; do
-    if test -f "$_d/coraza/coraza.h"; then
-        coraza_result_hdr="$_d/coraza/coraza.h"
-        break
-    fi
-done
-if test -n "$coraza_result_hdr" \
-    && grep -q 'CORAZA_INTERRUPTION' "$coraza_result_hdr"; then
-    echo " + libcoraza result enum found ($coraza_result_hdr): CORAZA_HAS_RESULT_ENUM"
-    CFLAGS="$CFLAGS -DCORAZA_HAS_RESULT_ENUM=1"
-else
+# the preprocessor and cannot be tested with `#ifdef` in the C sources.  Detect
+# the enum with a real compile probe (nginx's auto/feature) so the check uses the
+# *same* compiler and include flags the module is built with — a fixed-path grep
+# of /usr/local/include and /usr/include would miss a coraza.h supplied via
+# --with-cc-opt=-I<dir>, leave CORAZA_HAS_RESULT_ENUM undefined, and wrongly apply
+# the legacy `ret != 0` contract (treating CORAZA_INTERRUPTION == 1 as a fatal
+# error → spurious HTTP 500).  On success -DCORAZA_HAS_RESULT_ENUM is passed to
+# the connector; ngx_http_coraza_process_body_failed() reads this macro.
+ngx_feature="libcoraza result enum (CORAZA_INTERRUPTION)"
+ngx_feature_name="CORAZA_HAS_RESULT_ENUM"
+ngx_feature_run=no
+ngx_feature_incs="#include <coraza/coraza.h>"
+ngx_feature_path=
+ngx_feature_libs=
+ngx_feature_test="int r = (int) CORAZA_INTERRUPTION; (void) r;"
+. auto/feature
+
+if test $ngx_found != yes; then
     echo " + libcoraza result enum NOT found: using legacy ret!=0 contract"
 fi
 

--- a/config
+++ b/config
@@ -9,6 +9,35 @@
 # path of libyajl.so's installation
 
 ngx_addon_name="ngx_http_coraza_module"
+
+# Detect the libcoraza result-code contract at build time.
+#
+# libcoraza >= 1.6 ships `typedef enum coraza_result_t { CORAZA_ERROR = -1,
+# CORAZA_OK = 0, CORAZA_INTERRUPTION = 1 }`.  On that contract the body-phase
+# process calls return -1 on engine error and 1 on interruption, so "failed"
+# means `ret < 0`.  Older libcoraza has no such enum and returns 1 on error,
+# 0 on success, so "failed" means `ret != 0`.
+#
+# CORAZA_INTERRUPTION is an *enum member*, not a #define, so it is invisible to
+# the preprocessor and cannot be tested with `#ifdef` in the C sources.  Grep
+# the installed header here and pass -DCORAZA_HAS_RESULT_ENUM so the connector
+# can select the correct contract.  ngx_http_coraza_process_body_failed() reads
+# this macro.
+coraza_result_hdr=""
+for _d in /usr/local/include /usr/include; do
+    if test -f "$_d/coraza/coraza.h"; then
+        coraza_result_hdr="$_d/coraza/coraza.h"
+        break
+    fi
+done
+if test -n "$coraza_result_hdr" \
+    && grep -q 'CORAZA_INTERRUPTION' "$coraza_result_hdr"; then
+    echo " + libcoraza result enum found ($coraza_result_hdr): CORAZA_HAS_RESULT_ENUM"
+    CFLAGS="$CFLAGS -DCORAZA_HAS_RESULT_ENUM=1"
+else
+    echo " + libcoraza result enum NOT found: using legacy ret!=0 contract"
+fi
+
 coraza_dependency="ngx_http_postpone_filter_module \
                    ngx_http_ssi_filter_module \
                    ngx_http_charset_filter_module \

--- a/src/ngx_http_coraza_body_filter.c
+++ b/src/ngx_http_coraza_body_filter.c
@@ -197,7 +197,24 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
         if (is_request_processed) {
             int ret;
 
-            coraza_process_response_body(ctx->coraza_transaction);
+            if (ngx_http_coraza_process_body_failed(
+                    coraza_process_response_body(ctx->coraza_transaction)))
+            {
+                /*
+                 * Phase 4 could not be evaluated; no interruption is set, so
+                 * the poll below would let the response through uninspected.
+                 * Fail closed exactly like the poll-error branch does.
+                 */
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                    "coraza: response body phase processing failed");
+                if (ctx->headers_delayed) {
+                    ctx->intervention_triggered = 1;
+                    ctx->headers_delayed = 0;
+                    return NGX_HTTP_INTERNAL_SERVER_ERROR;
+                }
+                return ngx_http_filter_finalize_request(r,
+                    &ngx_http_coraza_module, NGX_HTTP_INTERNAL_SERVER_ERROR);
+            }
 
             ret = ngx_http_coraza_process_intervention(ctx->coraza_transaction, r, 0);
             if (ret > 0) {

--- a/src/ngx_http_coraza_common.h
+++ b/src/ngx_http_coraza_common.h
@@ -151,13 +151,15 @@ typedef struct {
  *     a negative return is an engine error -> error iff ret < 0.
  *   - libcoraza < 1.6 has no enum and no interruption return from these calls:
  *     they return 1 on error, 0 on success -> error iff ret != 0.
- * CORAZA_INTERRUPTION is defined only by the >= 1.6 header, so its presence
- * selects the contract.
+ * CORAZA_INTERRUPTION is an enum *member*, not a #define, so it is invisible to
+ * the preprocessor and cannot be tested with #ifdef.  The addon `config` script
+ * greps the installed coraza.h and defines CORAZA_HAS_RESULT_ENUM when the enum
+ * is present; that macro selects the contract here.
  */
 static ngx_inline ngx_int_t
 ngx_http_coraza_process_body_failed(int ret)
 {
-#ifdef CORAZA_INTERRUPTION
+#ifdef CORAZA_HAS_RESULT_ENUM
     return ret < 0;
 #else
     return ret != 0;

--- a/src/ngx_http_coraza_common.h
+++ b/src/ngx_http_coraza_common.h
@@ -137,6 +137,34 @@ typedef struct {
 #endif
 
 
+/*
+ * coraza_process_request_body() / coraza_process_response_body() can fail to
+ * evaluate the phase at all (the Go engine returned an error, e.g. it could not
+ * parse the buffered body).  On such a failure NO interruption is recorded on
+ * the transaction, so the coraza_intervention() poll that follows returns
+ * nothing and the body phase is silently skipped while nginx still forwards the
+ * body -- a fail-open inspection bypass.  We must fail closed on that error.
+ *
+ * The error sentinel differs across libcoraza versions, so gate on the enum:
+ *   - libcoraza >= 1.6 ships coraza_result_t: CORAZA_OK(0), CORAZA_INTERRUPTION(1),
+ *     CORAZA_ERROR(-1).  Here 1 means "interrupted" (the poll handles it) and only
+ *     a negative return is an engine error -> error iff ret < 0.
+ *   - libcoraza < 1.6 has no enum and no interruption return from these calls:
+ *     they return 1 on error, 0 on success -> error iff ret != 0.
+ * CORAZA_INTERRUPTION is defined only by the >= 1.6 header, so its presence
+ * selects the contract.
+ */
+static ngx_inline ngx_int_t
+ngx_http_coraza_process_body_failed(int ret)
+{
+#ifdef CORAZA_INTERRUPTION
+    return ret < 0;
+#else
+    return ret != 0;
+#endif
+}
+
+
 extern ngx_module_t ngx_http_coraza_module;
 
 /* ngx_http_coraza_module.c */

--- a/src/ngx_http_coraza_pre_access.c
+++ b/src/ngx_http_coraza_pre_access.c
@@ -192,7 +192,19 @@ ngx_http_coraza_pre_access_handler(ngx_http_request_t *r)
             return ret;
         }
 
-        coraza_process_request_body(ctx->coraza_transaction);
+        if (ngx_http_coraza_process_body_failed(
+                coraza_process_request_body(ctx->coraza_transaction)))
+        {
+            /*
+             * The engine could not evaluate phase 2; no interruption is set,
+             * so the poll below would let the body through uninspected.  Fail
+             * closed rather than inspect nothing while nginx forwards the body.
+             */
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                "coraza: request body phase processing failed");
+            ctx->intervention_triggered = 1;
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        }
 
         ret = ngx_http_coraza_process_intervention(ctx->coraza_transaction, r, 0);
         if (r->error_page) {


### PR DESCRIPTION
> Part of the follow-up hardening series from a full-source audit; independent against main. Sibling of #96 / #100, but on the *process* call, not the *append* call.

## TL;DR
The scanner has two steps for a body: first it collects the bytes (append), then it actually reads the rules over them (process). #96 and #100 fixed the *collect* step failing open. This fixes the *read-the-rules* step: if that step errors out — say the engine can't parse the body it buffered — the old code just moved on and let the request/response through unscanned. Now: if the rule-check step can't run, we don't let the traffic past.

**Severity:** Medium (request- and response-body inspection bypass — fail-open)

## What
Both body phase-processing call sites discarded the return value:

- `coraza_process_request_body()` — `ngx_http_coraza_pre_access.c`
- `coraza_process_response_body()` — `ngx_http_coraza_body_filter.c`

Per the libcoraza contract these return an **engine error** when the phase could not be evaluated (the Go `ProcessRequestBody()` / `ProcessResponseBody()` returned an error):

```go
//export coraza_process_response_body
func coraza_process_response_body(t C.coraza_transaction_t) C.int {
    tx := fromRaw[types.Transaction](t)
    it, err := tx.ProcessResponseBody()
    if err != nil {
        return C.CORAZA_ERROR      // -1 on >=1.6
    }
    if it != nil {
        return C.CORAZA_INTERRUPTION
    }
    return C.CORAZA_OK
}
```

## Why that's a problem
On an engine error **no interruption is recorded on the transaction**. The `coraza_intervention()` poll that immediately follows therefore returns nothing, the body phase is treated as "clean", and nginx forwards the body to upstream / the client **uninspected** — a fail-open bypass. An attacker who can drive the engine into a body-processing error (a body it cannot parse) skips phase-2 / phase-4 evaluation entirely.

This is **not** caught by the existing hardening:
- #96 / #100 check the *append* calls (`coraza_append_request_body` / `coraza_append_response_body`) — a different step.
- #97 fails closed on a *negative intervention-poll* return — but a process error sets no interruption, so the poll never sees it.

## Fix
- Add an inline classifier `ngx_http_coraza_process_body_failed()` and fail closed with **500** on an engine error at both call sites.
- **Version-gated** on the libcoraza return contract, because the error sentinel moved between releases:
  - **libcoraza >= 1.6** ships `coraza_result_t`: `CORAZA_OK(0)`, `CORAZA_INTERRUPTION(1)`, `CORAZA_ERROR(-1)`. Here `1` means *interrupted* (the poll handles it) and only a **negative** return is an engine error → error iff `ret < 0`.
  - **libcoraza < 1.6** has no enum and no interruption return from these calls: `1` on error, `0` on success → error iff `ret != 0`.
  - `CORAZA_INTERRUPTION` is defined only by the >= 1.6 header, so `#ifdef CORAZA_INTERRUPTION` selects the correct comparison. This mirrors the version-gating already used for the intervention-poll path.
- The response side honours the `headers_delayed` state exactly as the surrounding intervention branches in the same filter do.

## Testing
Defensive check on an error path not reachable by black-box input in normal operation (`ProcessRequestBody` / `ProcessResponseBody` only error on an internal engine failure), so there is no Test::Nginx negative control for it — same situation as #96 / #100. The existing `t/coraza-request-body*.t` and `t/coraza-response-body*.t` confirm no regression on the success path. Both comparison arms are exercised by CI: the pinned gate builds one libcoraza version, and the fallback arm compiles under the other. CI (compile, sanitizer, fuzz, config-lint, debug build) is expected green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fail-closed request-body inspection: if phase 2 evaluation fails, the request is stopped with an internal server error and interruption is recorded.
  * Fail-closed response-body inspection: if phase 4 evaluation fails, the response is halted with an internal server error (with correct interruption behavior when headers were delayed).
  * Failure detection is now consistent across supported Coraza versions, reducing the risk of inspection being silently bypassed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->