### PR TITLE
ci: move all CI jobs to ubuntu-26.04 and enable http_v3_module

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   sanitizer-lite:
     name: Sanitizer lite (60s soak)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 45
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
@@ -120,7 +120,7 @@ jobs:
           SAN_CC="$SAN_LD -fno-sanitize=nonnull-attribute,null -fno-sanitize-recover=address"
           ./configure \
             --with-compat --with-debug --with-threads \
-            --with-http_ssl_module --with-http_v2_module \
+            --with-http_ssl_module --with-http_v2_module --with-http_v3_module \
             --with-http_realip_module --with-http_auth_request_module \
             --add-dynamic-module="$GITHUB_WORKSPACE" \
             --with-cc-opt="-DNGX_DEBUG_PALLOC=1 -g3 -O0 -fno-omit-frame-pointer -funwind-tables $SAN_CC $(pkg-config --cflags libpcre2-8)" \

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,7 +29,12 @@ jobs:
       contents: read
 
     name: ${{ matrix.label }}
-    runs-on: ubuntu-24.04
+    # ubuntu-26.04 ships OpenSSL 3.5, giving nginx native server-side QUIC for
+    # the http_v3_module below (and 0-RTT/early-data, which needs 3.5.1+).
+    # nginx CAN build HTTP/3 on older OpenSSL via its QUIC compatibility layer
+    # (verified: builds fine on 24.04's OpenSSL 3.0.13) -- we run on 26.04 to
+    # exercise the native QUIC path production uses, not the compat shim.
+    runs-on: ubuntu-26.04
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       CCACHE_MAXSIZE: 500M
@@ -200,6 +205,7 @@ jobs:
           --with-http_realip_module \
           --with-http_auth_request_module \
           --with-http_v2_module \
+          --with-http_v3_module \
           --with-http_sub_module
 
       - name: Compile dynamic module and install

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   bump:
     name: Recompute pins + open PR
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: write        # create the bump branch
       pull-requests: write   # open the PR

--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -61,7 +61,7 @@ jobs:
     # connector correctness is already exercised by the arm64 memcheck/helgrind
     # soaks below.
     name: Fuzz (ngx_str_to_char)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 30
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
@@ -155,7 +155,7 @@ jobs:
         arch: [amd64]
         include:
           - arch: amd64
-            runner: ubuntu-24.04
+            runner: ubuntu-26.04
     steps:
       - name: Checkout module
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -222,6 +222,7 @@ jobs:
             --with-threads
             --with-http_ssl_module
             --with-http_v2_module
+            --with-http_v3_module
             --with-http_realip_module
             --with-http_auth_request_module
             --add-dynamic-module="$GITHUB_WORKSPACE"
@@ -288,7 +289,7 @@ jobs:
         arch: [amd64]
         include:
           - arch: amd64
-            runner: ubuntu-24.04
+            runner: ubuntu-26.04
     steps:
       - name: Checkout module
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -355,6 +356,7 @@ jobs:
             --with-threads
             --with-http_ssl_module
             --with-http_v2_module
+            --with-http_v3_module
             --with-http_realip_module
             --with-http_auth_request_module
             --add-dynamic-module="$GITHUB_WORKSPACE"
@@ -408,7 +410,7 @@ jobs:
 
   scanners:
     name: Security scanners
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 20
     steps:
       - name: Checkout module
@@ -509,7 +511,7 @@ jobs:
 
   codeql:
     name: CodeQL (deep)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 40
     permissions:
       contents: read
@@ -570,7 +572,7 @@ jobs:
           cd "nginx-${NGINX_VERSION}"
           ./configure \
             --with-compat --with-debug --with-threads \
-            --with-http_ssl_module --with-http_v2_module \
+            --with-http_ssl_module --with-http_v2_module --with-http_v3_module \
             --add-dynamic-module="$GITHUB_WORKSPACE"
           make modules
 
@@ -581,7 +583,7 @@ jobs:
 
   asan:
     name: ASan/UBSan soak (deep, 300s)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 90
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
@@ -662,7 +664,7 @@ jobs:
           SAN_CC="$SAN_LD -fno-sanitize=nonnull-attribute,null -fno-sanitize-recover=address"
           ./configure \
             --with-compat --with-debug --with-threads \
-            --with-http_ssl_module --with-http_v2_module \
+            --with-http_ssl_module --with-http_v2_module --with-http_v3_module \
             --with-http_realip_module --with-http_auth_request_module \
             --add-dynamic-module="$GITHUB_WORKSPACE" \
             --with-cc-opt="-DNGX_DEBUG_PALLOC=1 -g3 -O0 -fno-omit-frame-pointer -funwind-tables $SAN_CC $(pkg-config --cflags libpcre2-8)" \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze C
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 40
     permissions:
       contents: read
@@ -112,7 +112,7 @@ jobs:
           cd "nginx-${NGINX_VERSION}"
           ./configure \
             --with-compat --with-debug --with-threads \
-            --with-http_ssl_module --with-http_v2_module \
+            --with-http_ssl_module --with-http_v2_module --with-http_v3_module \
             --add-dynamic-module="$GITHUB_WORKSPACE"
           # make modules only — nginx core is never compiled, so CodeQL's
           # database contains only our TUs.

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   fuzz-regression:
     name: Fuzz regression (120s)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 30
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -27,11 +27,11 @@ jobs:
         arch: [amd64, arm64]
         include:
           - arch: amd64
-            runner: ubuntu-24.04
+            runner: ubuntu-26.04
             deb_arch: amd64
             rpm_arch: x86_64
           - arch: arm64
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-26.04-arm
             deb_arch: arm64
             rpm_arch: aarch64
 
@@ -128,6 +128,7 @@ jobs:
           --with-http_realip_module \
           --with-http_auth_request_module \
           --with-http_v2_module \
+          --with-http_v3_module \
           --with-http_sub_module
 
       - name: Compile dynamic module
@@ -230,9 +231,9 @@ jobs:
         pkg_type: [deb, rpm]
         include:
           - arch: amd64
-            runner: ubuntu-24.04
+            runner: ubuntu-26.04
           - arch: arm64
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-26.04-arm
 
     steps:
       - name: Download packages artifact

--- a/.github/workflows/security-scanners.yml
+++ b/.github/workflows/security-scanners.yml
@@ -39,7 +39,7 @@ permissions:
 jobs:
   scanners:
     name: Security scanners
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 25
     steps:
       - name: Checkout module
@@ -95,7 +95,7 @@ jobs:
           cd "nginx-${NGINX_VERSION}"
           ./configure \
             --with-compat --with-debug --with-threads \
-            --with-http_ssl_module --with-http_v2_module \
+            --with-http_ssl_module --with-http_v2_module --with-http_v3_module \
             --add-dynamic-module="$GITHUB_WORKSPACE"
 
       # clang-tidy must PARSE common.h's `#include "coraza/coraza.h"`. That header
@@ -125,7 +125,7 @@ jobs:
           N="$GITHUB_WORKSPACE/nginx-${NGINX_VERSION}"
           INCLUDES="-I$N/src/core -I$N/src/event -I$N/src/event/modules \
             -I$N/src/os/unix -I$N/objs -I$N/src/http -I$N/src/http/modules \
-            -I$N/src/http/v2 -I$GITHUB_WORKSPACE/src \
+            -I$N/src/http/v2 -I$N/src/http/v3 -I$N/src/event/quic -I$GITHUB_WORKSPACE/src \
             -I/usr/local/include -I/usr/include"
           status=0
           for src in "$GITHUB_WORKSPACE"/src/*.c; do

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -40,7 +40,7 @@ permissions:
 jobs:
   memcheck-fuzz-corpus:
     name: Memcheck (fuzz corpus replay)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 20
     steps:
       - name: Checkout module


### PR DESCRIPTION
Moves all CI jobs to ubuntu-26.04 and adds --with-http_v3_module to the nginx builds.

@fzipi — this lets CI exercise nginx HTTP/3 against native OpenSSL 3.5 server-side QUIC (the path modern production uses) and covers 0-RTT/early-data (needs OpenSSL 3.5.1+). Prerequisite for testing #83.

Note: HTTP/3 does NOT require OpenSSL 3.5 to build — nginx builds it on OpenSSL 1.1.1+ via its QUIC compatibility layer (verified: builds fine on 24.04's OpenSSL 3.0.13). So the runner bump is about the native-QUIC test target + toolchain consistency, not a hard build requirement.

release/stale stay on ubuntu-latest. Heads-up: the sanitizer/valgrind/scanner jobs get a newer toolchain — the scanners' clang-tidy include list needed src/event/quic + src/http/v3 added (done here) once h3 pulls in ngx_event_quic.h.