### PR TITLE
release: prepare 0.20.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,25 @@
+libnginx-mod-http-coraza (0.20.0-1) unstable; urgency=low
+
+  * New upstream release 0.20.0.
+  * Security: fail closed when request-body, response-body, or body-phase
+    processing fails in Coraza, and on NGX_ERROR from the intervention handler;
+    always set the intervention flag when one fires; validate the transaction
+    handle in create_ctx.
+  * Bound worker memory: cap delayed response-body buffering, bound buffering of
+    uninspected file-backed streams, and skip the header delay for SSE streams
+    (upstream #81) and HEAD responses.
+  * Correctness: report REQUEST_PROTOCOL/RESPONSE_PROTOCOL in slash-delimited
+    form and report HTTP/3 to the WAF; sanitize synthesized redirect and
+    HTTP/2/3 response headers; guard size_t-to-int narrowing at the cgo boundary.
+  * Performance: submit request/response headers in a single cgo call with a
+    per-header fallback, and cut per-request CGO crossings on the hot path;
+    configurable response-header delay via coraza_delay_response_headers.
+  * Build: require libcoraza 1.4 ABI, keep libcoraza loaded for the worker
+    lifetime, and probe the libcoraza result-code contract at configure time.
+  * The bulk of this release was contributed by Thijs Eilander (@eilandert).
+
+ -- Pierre Pomes <pierre.pomes@gmail.com>  Mon, 27 Jul 2026 12:00:00 +0000
+
 libnginx-mod-http-coraza (0.11.4-1) unstable; urgency=low
 
   * New upstream release 0.11.4.


### PR DESCRIPTION
Cuts the 0.20.0 release for the hardening series (most of it @eilandert's work) and prepares the Debian packaging changelog.

**What this does**
- Adds the curated `debian/changelog` entry for `0.20.0-1` — the ~90-line commit log deduped (nearly every fix landed as two commits) into grouped, human-readable bullets.
- Carries a `Release-As: 0.20.0` footer, so on merge release-please updates its release PR (#79) from the auto-proposed **0.11.5** to **0.20.0**.

Thanks @eilandert for the series.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Debian package to the latest upstream release, version 0.20.0.
  * Added configurable header-delay support and improved resource limits for worker memory and buffering.
* **Bug Fixes**
  * Improved fail-closed security behavior and intervention handling.
  * Enhanced protocol reporting and input sanitization.
  * Improved compatibility with the latest Coraza library ABI.
* **Performance**
  * Reduced processing overhead for faster request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->