### PR TITLE
ci: re-pin versions.env in place instead of regenerating it

### DIFF
--- a/.github/scripts/compute-versions.sh
+++ b/.github/scripts/compute-versions.sh
@@ -68,48 +68,50 @@ ANGIE_SHA="$(sha_of_url "https://github.com/webserver-llc/angie/archive/refs/tag
 CRS_SHA="$(sha_of_url "https://github.com/coreruleset/coreruleset/archive/refs/tags/v${CRS}.tar.gz")"
 LIBCORAZA_SHA="$(sha_of_url "https://github.com/corazawaf/libcoraza/archive/refs/tags/${LIBCORAZA}.zip")"
 
-# Keep GO_FTW_VERSION from the current file (renovate owns it).
-GO_FTW="$(grep -E '^GO_FTW_VERSION=' "$VERSIONS_FILE" | cut -d= -f2)"
-
-cat > "$VERSIONS_FILE" <<EOF
-# Central version + sha256 pins for all CI workflows.
+# Rewrite the pins IN PLACE, one key at a time. This script owns only the keys
+# listed in `set_pin` calls below; every other line of versions.env — comments,
+# blank lines, and hand-maintained pins like NGINX_TESTS_* (no upstream
+# releases, pinned to an immutable commit) and FALLBACK_LIBCORAZA_* (held at
+# 1.4.x on purpose so ci-deep keeps exercising the pre-1.6 fallback path) —
+# is carried through untouched.
 #
-# SINGLE SOURCE OF TRUTH. Every workflow sources this file into \$GITHUB_ENV as
-# its first step (via .github/scripts/load-versions.sh); the monthly bump.yml
-# job rewrites it and opens a PR. Tarballs/zips are pinned by version string
-# (release archives are immutable) AND verified against the sha256 recorded
-# here, so a compromised/changed upstream archive fails the build.
-#
-# Regenerate with .github/scripts/compute-versions.sh (bump.yml runs it monthly).
-# Keep KEY=value, no spaces, no quotes — this file is both \`source\`d and \`cat\`d.
+# Do NOT go back to regenerating the whole file from a heredoc: that silently
+# deletes any pin the heredoc does not know about, which is how the
+# NGINX_TESTS_* and FALLBACK_LIBCORAZA_* pins were lost once already.
 
-# nginx mainline (odd minor) — built + prove + go-ftw in build.yml
-NGINX_MAINLINE=${NGX_MAINLINE}
-NGINX_MAINLINE_SHA256=${NGX_MAINLINE_SHA}
+# set_pin KEY VALUE — replace the value of an existing KEY=... line, preserving
+# its position and the comment above it. Missing key = the file and this script
+# have drifted apart, which is a bug in one of them; fail loudly rather than
+# appending an orphan line at the bottom.
+set_pin() {
+  local key="$1" val="$2"
+  grep -qE "^${key}=" "$VERSIONS_FILE" || {
+    echo "::error::${key} not found in ${VERSIONS_FILE} — add it there first" >&2
+    exit 1
+  }
+  # Value is passed through the environment, not `awk -v` (which expands \n and
+  # friends) and not sed (where & and \1 are replacement metacharacters), so the
+  # pin lands byte-for-byte as resolved. Matters: these are sha256 values.
+  key="$key" val="$val" awk \
+    'index($0, ENVIRON["key"] "=") == 1 { print ENVIRON["key"] "=" ENVIRON["val"]; next } { print }' \
+    "$VERSIONS_FILE" > "$tmp/versions.env"
+  mv "$tmp/versions.env" "$VERSIONS_FILE"
+}
 
-# nginx stable (even minor) — built + prove + go-ftw in build.yml
-NGINX_STABLE=${NGX_STABLE}
-NGINX_STABLE_SHA256=${NGX_STABLE_SHA}
-
-# nginx version used by the deep/soak/scanner jobs (mainline)
-NGINX_VERSION=${NGX_MAINLINE}
-NGINX_VERSION_SHA256=${NGX_MAINLINE_SHA}
-
-# Angie (webserver-llc) — build-only cell in build.yml; full soak in ci-deep
-ANGIE_VERSION=${ANGIE}
-ANGIE_SHA256=${ANGIE_SHA}
-
-# libcoraza (cgo shared lib the module links against)
-LIBCORAZA_VERSION=${LIBCORAZA}
-LIBCORAZA_SHA256=${LIBCORAZA_SHA}
-
-# OWASP CRS — LTS line (used by build.yml go-ftw regression run)
-CRS_VERSION=${CRS}
-CRS_SHA256=${CRS_SHA}
-
-# go-ftw (test runner, installed via \`go install\`, pinned by tag only)
-GO_FTW_VERSION=${GO_FTW}
-EOF
+set_pin NGINX_MAINLINE        "$NGX_MAINLINE"
+set_pin NGINX_MAINLINE_SHA256 "$NGX_MAINLINE_SHA"
+set_pin NGINX_STABLE          "$NGX_STABLE"
+set_pin NGINX_STABLE_SHA256   "$NGX_STABLE_SHA"
+set_pin NGINX_VERSION         "$NGX_MAINLINE"
+set_pin NGINX_VERSION_SHA256  "$NGX_MAINLINE_SHA"
+set_pin ANGIE_VERSION         "$ANGIE"
+set_pin ANGIE_SHA256          "$ANGIE_SHA"
+set_pin LIBCORAZA_VERSION     "$LIBCORAZA"
+set_pin LIBCORAZA_SHA256      "$LIBCORAZA_SHA"
+set_pin CRS_VERSION           "$CRS"
+set_pin CRS_SHA256            "$CRS_SHA"
+# GO_FTW_VERSION is renovate's; NGINX_TESTS_* and FALLBACK_LIBCORAZA_* are
+# hand-pinned. None are set here — they survive by not being touched.
 
 echo "----- new versions.env -----"
 echo "nginx mainline: ${NGX_MAINLINE}"

--- a/.github/versions.env
+++ b/.github/versions.env
@@ -2,14 +2,17 @@
 #
 # SINGLE SOURCE OF TRUTH. Every workflow sources this file into $GITHUB_ENV as
 # its first step (via .github/scripts/load-versions.sh); the monthly bump.yml
-# job rewrites it and opens a PR. Tarballs/zips are pinned by version string
+# job re-pins it and opens a PR. Tarballs/zips are pinned by version string
 # (release archives are immutable) AND verified against the sha256 recorded
 # here, so a compromised/changed upstream archive fails the build.
 #
 # To bump manually: edit versions here, refresh the matching *_SHA256 with
 #   .github/scripts/fetch-verify.sh <url> - <out>   (prints the sha on mismatch)
-# or just let bump.yml do it. Keep KEY=value, no spaces, no quotes — this file
-# is both `source`d by scripts and `cat`d into $GITHUB_ENV.
+# or just let bump.yml do it. compute-versions.sh rewrites ONLY the keys it
+# resolves, in place; pins it does not own (GO_FTW_VERSION, NGINX_TESTS_*,
+# FALLBACK_LIBCORAZA_*) are maintained by hand here and survive the bump.
+# Keep KEY=value, no spaces, no quotes — this file is both `source`d by scripts
+# and `cat`d into $GITHUB_ENV.
 
 # nginx mainline (odd minor) — built + prove + go-ftw in build.yml
 NGINX_MAINLINE=1.31.3
@@ -38,8 +41,8 @@ LIBCORAZA_SHA256=8c882d06c8d5ef76cb96a7115e7c280d73026470e85ee14126cf9360ca0a24c
 
 # Pre-1.6 pin for the ci-deep `fallback` job ONLY — it exists to exercise the
 # per-header fallback path (dlsym-resolved in ngx_http_coraza_dl.c) that the
-# >=1.6 gate above never takes. bump.yml must NOT advance this past 1.4.x or the
-# job stops testing what it is for.
+# >=1.6 gate above never takes. compute-versions.sh must NOT advance this past
+# 1.4.x or the job stops testing what it is for.
 FALLBACK_LIBCORAZA_VERSION=v1.4.0
 FALLBACK_LIBCORAZA_SHA256=9f5f7f4cf291097cc6340d243e73267b5d1c4274c538961f5f6bbd3062611940
 


### PR DESCRIPTION
> Found while looking into why the "nginx mainline (full)" job is red on #104. That PR is the first monthly bump to hit this, but the bug is in the bump machinery rather than in the bump itself, so it is fixed here against `main` and stands on its own.

## TL;DR

Once a month a scheduled job goes out, finds the newest nginx/Angie/CRS/libcoraza releases, and writes them into `.github/versions.env` so CI builds against known archives with known checksums. The script does that by printing a brand-new copy of the file from a fixed template. Anything not in that template is simply gone. Four pins are maintained by hand and are not in the template, so each monthly run deletes them.

`compute-versions.sh` ends with `cat > "$VERSIONS_FILE" <<EOF`, a heredoc listing the keys the resolver knows about. `GO_FTW_VERSION` survives only because it is read back first:

```sh
GO_FTW="$(grep -E '^GO_FTW_VERSION=' "$VERSIONS_FILE" | cut -d= -f2)"
```

Four other keys needed that treatment and never got it.

## What breaks

`NGINX_TESTS_REF` / `NGINX_TESTS_SHA256` — [build-test.yml:307-308](.github/workflows/build-test.yml#L307-L308) still consumes them. Both expand empty, so the job fetches `https://github.com/nginx/nginx-tests/archive/.tar.gz` and verifies it against an empty sha. That is the failing job on #104, and it is the only red one there because no other cell touches these.

`FALLBACK_LIBCORAZA_VERSION` / `FALLBACK_LIBCORAZA_SHA256` — [ci-deep.yml:747-748](.github/workflows/ci-deep.yml#L747-L748) exports them to hold libcoraza at 1.4.x for the fallback job. That job is monthly-scheduled, so its loss does not show up on PR CI at all; it would have surfaced later as a fallback job building against an empty pin.

## Fix

`set_pin()` rewrites one key in place and leaves every other line alone, so comments, blank lines and hand-maintained pins survive by default rather than by being remembered. A key that is missing from `versions.env` is now a hard error instead of an orphan line appended at the bottom.

Values reach `awk` through the environment rather than `-v`, which expands escape sequences, and not `sed`, where `&` and `\1` are replacement metacharacters. These are sha256 pins, so byte-for-byte matters more than it looks.

The comments explaining why the fallback pin must stay on 1.4.x and why nginx-tests is commit-pinned are updated to name `compute-versions.sh` rather than `bump.yml`, since that is where the constraint is actually enforced.

No pin values change in this PR.

## Testing

- `bash -n` clean; `shellcheck` reports nothing new (four pre-existing SC2015 infos on untouched lines)
- drove `set_pin` against a real copy of `versions.env`: only the targeted keys change, and all five hand-maintained pins survive
- missing-key guard exits 1 with an `::error::` line
- `set_pin CRS_VERSION 'a\1b&c'` stores `a\1b&c` verbatim, which is what caught the `awk -v` escape expansion in the first place
- file still `source`s clean with no empty values, and the previously failing nginx-tests URL resolves to the full commit sha
- cross-checked every `$NGINX_*` / `$CRS_*` / `$ANGIE_*` / `$LIBCORAZA_*` / `$GO_FTW_*` reference across `.github/` against the defined keys: no dangling references, nothing unreferenced

The monthly resolver path itself is not exercised here; it hits five upstream APIs and needs a scheduled run to prove out.

## After this lands

#104 needs a rebase (or a re-run of the bump) to pick up the restored pins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Version updates now preserve comments, blank lines, and pins managed outside the automatic update process.
  * Missing expected version entries are reported instead of being silently recreated or overwritten.

* **Documentation**
  * Clarified which version pins are updated automatically and documented excluded fallback pins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->