### PR TITLE
fix: write the audit record when an internal redirect hides the LOG-phase ctx

### DIFF
--- a/src/ngx_http_coraza_log.c
+++ b/src/ngx_http_coraza_log.c
@@ -36,5 +36,11 @@ ngx_http_coraza_log_handler(ngx_http_request_t *r)
 
     coraza_process_logging(ctx->coraza_transaction);
 
+    /*
+     * Claim the transaction so the ngx_http_coraza_cleanup() fallback does not
+     * log it a second time.
+     */
+    ctx->logged = 1;
+
     return NGX_OK;
 }

--- a/src/ngx_http_coraza_module.c
+++ b/src/ngx_http_coraza_module.c
@@ -142,6 +142,31 @@ void ngx_http_coraza_cleanup(void *data)
 
 	ctx = (ngx_http_coraza_ctx_t *)data;
 
+	/*
+	 * Last chance to run ProcessLogging.
+	 *
+	 * The LOG-phase handler is the normal place for it, but it can be missed
+	 * entirely: nginx wipes r->ctx on every internal redirect
+	 * (ngx_http_internal_redirect(), ngx_http_named_location()) and in
+	 * ngx_http_filter_finalize_request(), so an interrupted transaction routed
+	 * through error_page / X-Accel-Redirect reaches the LOG phase with no ctx
+	 * to find -- and if the error location is `coraza off`, with mcf->enable
+	 * == 0 as well.  Either way the handler bails out and the transaction is
+	 * freed here having never been logged, losing the audit record for the
+	 * very request that was blocked.
+	 *
+	 * Only phases 2..4 are affected: the request-headers poll passes
+	 * early_log=1 and has already logged.
+	 *
+	 * This cleanup is registered on r->pool, which ngx_http_free_request()
+	 * destroys *after* ngx_http_log_request(), so the transaction is still
+	 * alive here and RESPONSE_STATUS already holds the final status.
+	 */
+	if (!ctx->logged) {
+		coraza_process_logging(ctx->coraza_transaction);
+		ctx->logged = 1;
+	}
+
 	if (coraza_free_transaction(ctx->coraza_transaction) != NGX_OK) {
 		dd("cleanup -- transaction free failed");
 	}

--- a/t/coraza-error-page-audit-log.t
+++ b/t/coraza-error-page-audit-log.t
@@ -1,0 +1,132 @@
+#!/usr/bin/perl
+
+# Tests for Coraza-nginx connector: a transaction the WAF interrupts in phase 2
+# must still produce an audit record when the denial status is routed through an
+# error_page.
+#
+# nginx wipes r->ctx on every internal redirect (ngx_http_internal_redirect(),
+# ngx_http_named_location()), so the LOG-phase handler finds no Coraza context
+# for the request that was actually blocked -- and if the error location is
+# `coraza off`, mcf->enable is 0 there too.  Either way the handler bails and
+# ProcessLogging is never called, silently dropping the audit record for the
+# request that was blocked.  Phases 2..4 are affected; the request-headers poll
+# passes early_log=1 and is not.
+#
+# ngx_http_coraza_cleanup() (registered on r->pool, which nginx destroys after
+# ngx_http_log_request()) runs ProcessLogging as a fallback when ctx->logged is
+# still unset, and the LOG handler sets ctx->logged so the record is never
+# written twice.
+#
+# Note: the blocked locations serve a static file rather than `return 200`.
+# ngx_http_rewrite_module handles `return` in the REWRITE phase and finalizes
+# the request there, so PREACCESS -- where the connector runs Coraza phase 2 --
+# would never be reached.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http/);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:%%PORT_8080%%;
+        server_name  localhost;
+        default_type text/plain;
+        root         %%TESTDIR%%;
+
+        coraza on;
+        coraza_rules '
+            SecRuleEngine On
+            SecRequestBodyAccess On
+            SecAuditEngine On
+            SecAuditLogParts ABZ
+            SecAuditLogType Serial
+            SecAuditLog %%TESTDIR%%/audit.txt
+            SecRule ARGS:x "@streq boom" "id:900,phase:2,deny,log,auditlog,status:403"
+        ';
+
+        # Denied in phase 2, then sent through an internal redirect, which
+        # clears r->ctx before the LOG phase runs.
+        location = /page-ep.html {
+            error_page 403 /denied.html;
+        }
+
+        # Same rule, no error_page: the LOG-phase handler still finds the ctx.
+        # Guards the fallback against logging that transaction a second time.
+        location = /page-plain.html {
+        }
+
+        # The error-page target has the WAF off, so no second transaction is
+        # created for the internal request.
+        location = /denied.html {
+            coraza off;
+            return 403 "denied\n";
+        }
+    }
+}
+EOF
+
+$t->write_file('page-ep.html', 'should not reach');
+$t->write_file('page-plain.html', 'should not reach');
+
+$t->run();
+$t->todo_alerts();
+$t->plan(5);
+
+###############################################################################
+
+my $d = $t->testdir();
+
+# Blocked in phase 2; the response body comes from the error_page.
+my $r = http_get('/page-ep.html?x=boom');
+like($r, qr/^HTTP\S+ 403/, 'phase-2 denial routed through error_page keeps 403');
+like($r, qr/denied/, 'error_page body served');
+
+# The same rule without an error_page: the ordinary LOG-phase path.
+like(http_get('/page-plain.html?x=boom'), qr/^HTTP\S+ 403/,
+    'phase-2 denial without error_page');
+
+# Control: a request matching nothing is served normally.
+like(http_get('/page-plain.html?x=safe'), qr/^HTTP\S+ 200/,
+    'clean request is served');
+
+my $audit = do {
+    local $/ = undef;
+    open my $fh, '<', "$d/audit.txt" or die "could not open audit log: $!";
+    <$fh>;
+};
+
+# Without the pool-cleanup fallback the first count is 0: the record for the
+# blocked request is lost.  The second count guards against the fallback
+# duplicating a transaction the LOG handler already logged.
+my @counts = (
+    scalar(() = $audit =~ m!/page-ep\.html\?x=boom!g),
+    scalar(() = $audit =~ m!/page-plain\.html\?x=boom!g),
+);
+is_deeply(\@counts, [1, 1],
+    'exactly one audit record per denial, with and without error_page');


### PR DESCRIPTION
## Problem

A transaction the WAF interrupts in **phase 2 or later** produces **no audit record at all** when the denial status is routed through an `error_page`.

nginx zeroes `r->ctx` for every module on an internal redirect — `ngx_http_internal_redirect()`, `ngx_http_named_location()` — and in `ngx_http_filter_finalize_request()`. So the sequence is:

1. A rule interrupts in phase 2; `ngx_http_coraza_pre_access.c` returns 403.
2. `ngx_http_special_response_handler()` finds the `error_page` and internally redirects. `r->ctx` is wiped.
3. `NGX_HTTP_LOG_PHASE` runs. `ngx_http_coraza_log_handler()` finds `ctx == NULL` and returns — or, if the error location is `coraza off`, bails on `mcf->enable != 1`.
4. `ngx_http_coraza_cleanup()` frees the transaction. `ProcessLogging` was never called.

The blocked request appears only as a status code in the access log.

Phase 1 is unaffected: `ngx_http_coraza_rewrite.c` polls with `early_log=1` and logs inline. Phases 2, 3 and 4 all pass `early_log=0` and depend on the LOG phase. Since CRS blocks with `949110` in phase 2, a deployment with `error_page 403 ...` loses the audit record for **every** CRS block.

Adding `coraza on` to the error location does not fix it — the original context is already gone, so that just creates a second transaction for the error page.

## Fix

Run `ProcessLogging` from the `r->pool` cleanup when the LOG-phase handler did not get there:

- `ngx_http_coraza_cleanup()` calls `coraza_process_logging()` when `ctx->logged` is still unset.
- `ngx_http_coraza_log_handler()` sets `ctx->logged = 1`, so the two paths are mutually exclusive and an ordinary request is still logged exactly once.

`ngx_http_free_request()` calls `ngx_http_log_request()` *before* `ngx_destroy_pool(r->pool)`, so at cleanup time the transaction is still alive and `RESPONSE_STATUS` already carries the final status — the record is complete, and `SecAuditEngine RelevantOnly` still matches correctly.

`ctx->logged` already exists in `ngx_http_coraza_common.h` and was already set by the `early_log` path in `ngx_http_coraza_process_intervention()`; this only makes the normal LOG-phase path claim it too.

## Test

`t/coraza-error-page-audit-log.t` covers both directions:

- a phase-2 denial routed through `error_page` → exactly **1** audit record (0 before this change);
- the same denial without `error_page` → exactly **1** audit record (guards against the fallback double-logging);
- the 403 and the error-page body are unchanged, and a clean request is still served.

Note the blocked locations serve a static file rather than `return 200`: `ngx_http_rewrite_module` handles `return` in the REWRITE phase and finalizes there, so PREACCESS — where the connector runs Coraza phase 2 — would never be reached.

## Verification

Built against nginx 1.30.4 + libcoraza 1.6.0 (coraza v3.7.0).

- New test: fails on `main` (0 records for the blocked request), passes with the change.
- Full `prove coraza-*.t coraza.t` (60 files, 474 tests) run twice on the same tree, once with each binary: the **only** difference in the summary is `coraza-error-page-audit-log.t` going from FAIL to PASS. No other test changes state.

---
<sub>🤖 Generated by LastCoder | Upstream Fix | 85d7dfad-e9d8-4ab8-aafe-5101d446de3c</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured blocked requests consistently generate audit log records, including those routed through custom error pages or internal redirects.
  * Prevented duplicate audit entries for the same transaction.

* **Tests**
  * Added coverage verifying correct responses and exactly one audit record for denied requests with and without error-page handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->