### PR TITLE
docs: drop EOL 25.10 (questing) from PPA build targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ sudo apt update
 sudo apt install libnginx-mod-http-coraza
 ```
 
-This pulls in libcoraza automatically. Built for Ubuntu 24.04 (noble), 25.10 (questing), 26.04 (resolute) and 26.10 (stonking). Jammy (22.04) is not supported — its nginx packaging doesn't ship the `nginx-dev` / `dh-sequence-nginx` bits needed to build a dynamic module.
+This pulls in libcoraza automatically. Built for Ubuntu 24.04 (noble), 26.04 (resolute) and 26.10 (stonking). Jammy (22.04) is not supported — its nginx packaging doesn't ship the `nginx-dev` / `dh-sequence-nginx` bits needed to build a dynamic module.
 
 # Compilation
 


### PR DESCRIPTION
Ubuntu 25.10 (questing) reached end of life in 2026-07 and is no longer a PPA build target. Drop it from the supported-versions line; noble/resolute/stonking are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the PPA installation note to reflect the currently supported Ubuntu releases.
  * Clarified that Ubuntu 25.10 is no longer listed as supported; the existing Jammy limitation remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->