### PR TITLE
chore: pin libcoraza floor to 1.6, build against 1.7

### DIFF
--- a/.github/versions.env
+++ b/.github/versions.env
@@ -32,12 +32,14 @@ ANGIE_SHA256=47f99ce14bf2e3942017cc145c7ee69a267d61ba5a75ecf300609959de92be00
 
 # libcoraza (cgo shared lib the module links against)
 #
-# 1.6.0 is the FLOOR the connector's perf hot path needs: the bulk-header submit
+# 1.6 is the FLOOR the connector's perf hot path needs: the bulk-header submit
 # symbols and the OK-path intervention-poll gating only exist on >=1.6, so a
 # 1.4.x gate would compile/test only the per-header fallback and give a false
-# sense of coverage of the fast path. Debian ships 1.6.0, so the gate matches prod.
-LIBCORAZA_VERSION=v1.6.0
-LIBCORAZA_SHA256=8c882d06c8d5ef76cb96a7115e7c280d73026470e85ee14126cf9360ca0a24ca
+# sense of coverage of the fast path (debian/control pins libcoraza >= 1.6 to
+# match). This pin tracks the latest release so CI builds against what the PPA
+# ships.
+LIBCORAZA_VERSION=v1.7.0
+LIBCORAZA_SHA256=c0211b464a14a2bbfdaa0600617316bc908ed0c540dd287514b3f5826b6c6dfc
 
 # Pre-1.6 pin for the ci-deep `fallback` job ONLY — it exists to exercise the
 # per-header fallback path (dlsym-resolved in ngx_http_coraza_dl.c) that the

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -15,8 +15,8 @@ jobs:
     name: Package for nginx ${{ matrix.nginx_version }} (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
     env:
-      # renovate: depName=libcoraza packageName=corazawaf/libcoraza datasource=github-releases
-      LIBCORAZA_VERSION: v1.4.0
+      # LIBCORAZA_VERSION / LIBCORAZA_SHA256 are loaded from .github/versions.env
+      # (single source of truth) in the "Load libcoraza pin" step below.
       # sha256 of nginx-1.30.3.tar.gz from nginx.org — update together with the matrix
       NGINX_SHA256: "e5823dc6f45610993def93ebf6cfce68264af4958c77e874b7d20f3709001b8f"
       CCACHE_DIR: ${{ github.workspace }}/.ccache
@@ -38,6 +38,15 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # Load the shared libcoraza pin so the released artifact builds against
+      # the same version CI does (.github/versions.env is the single source of
+      # truth), instead of a stale hardcoded value.
+      - name: Load libcoraza pin
+        run: |
+          set -a; . .github/versions.env; set +a
+          echo "LIBCORAZA_VERSION=$LIBCORAZA_VERSION" >> "$GITHUB_ENV"
+          echo "LIBCORAZA_SHA256=$LIBCORAZA_SHA256" >> "$GITHUB_ENV"
 
       # Grab nginx source, from cache if possible, or from web
       - name: Grab nginx-${{ matrix.nginx_version }} cache
@@ -66,6 +75,7 @@ jobs:
         run: |
           cd ${{ github.workspace }}
           wget https://github.com/corazawaf/libcoraza/archive/refs/tags/${{ env.LIBCORAZA_VERSION }}.zip
+          echo "${LIBCORAZA_SHA256}  ${{ env.LIBCORAZA_VERSION }}.zip" | sha256sum -c -
           unzip -o ${{ env.LIBCORAZA_VERSION }}.zip
 
       # NB: no ccache / Go build-cache restore in this job. It runs only on

--- a/debian/control
+++ b/debian/control
@@ -4,14 +4,14 @@ Priority: optional
 Maintainer: Pierre Pomes <pierre.pomes@gmail.com>
 Build-Depends: debhelper-compat (= 13),
                dh-sequence-nginx,
-               libcoraza-dev
+               libcoraza-dev (>= 1.6)
 Standards-Version: 4.7.0
 Homepage: https://github.com/corazawaf/coraza-nginx
 Rules-Requires-Root: no
 
 Package: libnginx-mod-http-coraza
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, libcoraza1 (>= 1.4.0)
+Depends: ${misc:Depends}, ${shlibs:Depends}, libcoraza1 (>= 1.6)
 Description: Coraza WAF connector module for nginx
  Coraza is an open-source Web Application Firewall (WAF) engine.
  This module integrates the Coraza WAF with the nginx web server,

--- a/t/coraza-dynlib-contract.t
+++ b/t/coraza-dynlib-contract.t
@@ -17,7 +17,7 @@ my $root = "$FindBin::Bin/..";
 my $control = slurp("$root/debian/control");
 my $dl = slurp("$root/src/ngx_http_coraza_dl.c");
 
-like($control, qr/\blibcoraza1\s+\(>=\s*1\.4\.0\)/,
+like($control, qr/\blibcoraza1\s+\(>=\s*1\.6\)/,
 	'Debian package pins the libcoraza runtime ABI');
 
 unlike($dl, qr/Optional.*coraza_is_response_body_processable/s,


### PR DESCRIPTION
Pins the libcoraza floor so the build-time ABI (enum, from >= 1.6 headers) can't be paired at runtime with a pre-1.5 libcoraza, which would silently fail open on engine errors.

- `debian/control`: `Build-Depends: libcoraza-dev (>= 1.6)`, `Depends: libcoraza1 (>= 1.6)` (was `>= 1.4.0`).
- `versions.env`: build/test against the latest release, v1.7.0 (sha256 verified); comment clarified (1.6 is the floor, 1.7 is the build target).

The pre-1.6 per-header fallback path and its ci-deep `fallback` job stay as-is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the bundled Coraza library to version 1.7.0.
  * Raised package requirements to Coraza 1.6 or newer for improved compatibility.
  * Updated the release checksum to verify downloaded packages during builds.
  * Aligned packaging checks with the supported Coraza runtime version.
  * Ensured release artifacts are built against the latest supported library release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->