### PR TITLE
release: prepare 0.21.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+libnginx-mod-http-coraza (0.21.0-1) unstable; urgency=low
+
+  * New upstream release 0.21.0.
+  * Require libcoraza >= 1.7.0; support for older libcoraza is dropped. The
+    connector gates on coraza_version_num() both at build time (configure
+    fails against older headers) and at runtime (the worker refuses to start
+    against an older shared library), and always uses the tri-state
+    coraza_result_t return contract.
+
+ -- Pierre Pomes <pierre.pomes@gmail.com>  Sat, 29 Aug 2026 12:00:00 +0000
+
 libnginx-mod-http-coraza (0.20.0-1) unstable; urgency=low
 
   * New upstream release 0.20.0.


### PR DESCRIPTION
Cuts 0.21.0 and prepares the Debian packaging changelog.

**Why a release:** the libcoraza >= 1.7 requirement (drop of 1.4 support, gate on `coraza_version_num()`) landed as a `refactor:` commit, which does not trigger release-please. This carries `Release-As: 0.21.0` so a release is actually cut, and adds the matching `debian/changelog` entry.

**Version:** minor bump (0.20 → 0.21) — requiring libcoraza >= 1.7 is a breaking change for anyone on an older library.

After merge, merging release-please's PR tags v0.21.0; then the PPA is rebuilt against libcoraza 1.7.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.21.0-1.
  * Documented the requirement for libcoraza 1.7.0 or later.
  * Noted that older libcoraza versions are no longer supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->