### PR TITLE
perf: skip inaccessible request body buffering

### DIFF
--- a/src/ngx_http_coraza_common.h
+++ b/src/ngx_http_coraza_common.h
@@ -224,6 +224,7 @@ ngx_http_coraza_poll_after_process(ngx_http_coraza_ctx_t *ctx,
 /* ngx_http_coraza_dl.c */
 ngx_int_t ngx_http_coraza_dl_open(ngx_log_t *log);
 void ngx_http_coraza_dl_close(ngx_log_t *log);
+int ngx_http_coraza_is_request_body_accessible(coraza_transaction_t t);
 int ngx_http_coraza_is_response_body_processable(coraza_transaction_t t);
 /* Bulk header entry points (libcoraza 1.6+); guard every call with
  * ngx_http_coraza_bulk_headers_available() (forward-declared above). */

--- a/src/ngx_http_coraza_dl.c
+++ b/src/ngx_http_coraza_dl.c
@@ -37,6 +37,7 @@ typedef int                  (*fn_coraza_process_request_headers)(coraza_transac
 typedef int                  (*fn_coraza_append_request_body)(coraza_transaction_t, unsigned char *, int);
 typedef int                  (*fn_coraza_request_body_from_file)(coraza_transaction_t, char *);
 typedef int                  (*fn_coraza_process_request_body)(coraza_transaction_t);
+typedef int                  (*fn_coraza_is_request_body_accessible)(coraza_transaction_t);
 typedef int                  (*fn_coraza_add_response_header)(coraza_transaction_t, char *, int, char *, int);
 typedef int                  (*fn_coraza_append_response_body)(coraza_transaction_t, unsigned char *, int);
 typedef int                  (*fn_coraza_process_response_body)(coraza_transaction_t);
@@ -87,6 +88,7 @@ static fn_coraza_process_request_headers dl_process_request_headers;
 static fn_coraza_append_request_body     dl_append_request_body;
 static fn_coraza_request_body_from_file  dl_request_body_from_file;
 static fn_coraza_process_request_body    dl_process_request_body;
+static fn_coraza_is_request_body_accessible dl_is_request_body_accessible;
 static fn_coraza_add_response_header     dl_add_response_header;
 static fn_coraza_append_response_body    dl_append_response_body;
 static fn_coraza_process_response_body   dl_process_response_body;
@@ -172,6 +174,8 @@ ngx_http_coraza_dl_open(ngx_log_t *log)
     DL_SYM(dl_append_request_body,      coraza_append_request_body);
     DL_SYM(dl_request_body_from_file,   coraza_request_body_from_file);
     DL_SYM(dl_process_request_body,     coraza_process_request_body);
+    DL_SYM(dl_is_request_body_accessible,
+           coraza_is_request_body_accessible);
     DL_SYM(dl_add_response_header,      coraza_add_response_header);
     DL_SYM(dl_append_response_body,     coraza_append_response_body);
     DL_SYM(dl_process_response_body,    coraza_process_response_body);
@@ -330,6 +334,24 @@ int coraza_request_body_from_file(coraza_transaction_t t, char *file)
 int coraza_process_request_body(coraza_transaction_t t)
 {
     return dl_process_request_body(t);
+}
+
+/*
+ * ngx_http_coraza_is_request_body_accessible — wrapper around the
+ * coraza_is_request_body_accessible symbol.
+ *
+ * This predicate is valid after coraza_process_request_headers() and reports
+ * whether request-body bytes should be submitted for this transaction.  A
+ * false result skips only buffering and submission; coraza_process_request_body
+ * must still run because it evaluates phase-2 rules on non-body variables.
+ *
+ * libcoraza 1.7.0 introduced the symbol and is the connector's minimum
+ * supported version, so ngx_http_coraza_dl_open() resolves it as mandatory.
+ */
+int
+ngx_http_coraza_is_request_body_accessible(coraza_transaction_t t)
+{
+    return dl_is_request_body_accessible(t);
 }
 
 int coraza_add_response_header(coraza_transaction_t t, char *name,

--- a/src/ngx_http_coraza_pre_access.c
+++ b/src/ngx_http_coraza_pre_access.c
@@ -35,6 +35,50 @@ ngx_http_coraza_request_read(ngx_http_request_t *r)
 }
 
 
+/*
+ * Finish the request-body phase after any body submission.  This must also run
+ * when request-body access is off: Coraza still evaluates phase-2 rules on
+ * headers, URI arguments and other non-body variables in that case.
+ */
+static ngx_int_t
+ngx_http_coraza_process_request_body_phase(ngx_http_coraza_ctx_t *ctx,
+    ngx_http_request_t *r)
+{
+    int pret;
+    int ret;
+
+    pret = coraza_process_request_body(ctx->coraza_transaction);
+    if (ngx_http_coraza_process_body_failed(pret))
+    {
+        /*
+         * The engine could not evaluate phase 2; no interruption is set,
+         * so the poll below would let the body through uninspected.  Fail
+         * closed rather than inspect nothing while nginx forwards the body.
+         */
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+            "coraza: request body phase processing failed");
+        ctx->intervention_triggered = 1;
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    ret = ngx_http_coraza_poll_after_process(ctx, r, 0, pret);
+    if (r->error_page) {
+        return NGX_DECLINED;
+    }
+    if (ret < 0) {
+        /* NGX_ERROR from the intervention handler: fail closed. */
+        ctx->intervention_triggered = 1;
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+    if (ret > 0) {
+        ctx->intervention_triggered = 1;
+        return ret;
+    }
+
+    return NGX_DECLINED;
+}
+
+
 ngx_int_t
 ngx_http_coraza_pre_access_handler(ngx_http_request_t *r)
 {
@@ -71,9 +115,27 @@ ngx_http_coraza_pre_access_handler(ngx_http_request_t *r)
         return NGX_DONE;
     }
 
+    /*
+     * Request-header processing has already run in the rewrite handler, so
+     * libcoraza can now answer whether request-body bytes are accessible for
+     * this transaction.  When access is off, leave body_requested clear and
+     * let the eventual content handler read/forward the body; Coraza discards
+     * those bytes, so reading them here would only add buffering, copies and
+     * cgo crossings.
+     *
+     * body_requested also records that this predicate was true.  On the
+     * NGX_AGAIN resume path it prevents a second predicate call and a second
+     * ngx_http_read_client_request_body() call.
+     */
     if (ctx->body_requested == 0)
     {
         ngx_int_t rc = NGX_OK;
+
+        if (!ngx_http_coraza_is_request_body_accessible(
+                ctx->coraza_transaction))
+        {
+            return ngx_http_coraza_process_request_body_phase(ctx, r);
+        }
 
         ctx->body_requested = 1;
 
@@ -112,18 +174,17 @@ ngx_http_coraza_pre_access_handler(ngx_http_request_t *r)
     if (ctx->waiting_more_body == 0)
     {
         int ret = 0;
-        int pret = 0;
         int already_inspected = 0;
         char *file_name = NULL;
 
-        dd("request body is ready to be processed");
-
-        r->write_event_handler = ngx_http_core_run_phases;
+        dd("request body phase is ready to be processed");
 
         ngx_chain_t *chain = r->request_body->bufs;
 
         /* TODO: send chunks to Coraza as they arrive instead of waiting
          * for the full body, to reduce latency on large requests. */
+
+        r->write_event_handler = ngx_http_core_run_phases;
 
         if (r->request_body->temp_file != NULL) {
             ngx_str_t file_path = r->request_body->temp_file->file.name;
@@ -212,7 +273,7 @@ ngx_http_coraza_pre_access_handler(ngx_http_request_t *r)
          * returned any kind of intervention.
          */
 
-        /* Check for body limit intervention before processing rules */
+        /* Check for body limit intervention before processing rules. */
         ret = ngx_http_coraza_process_intervention(ctx, r, 0);
         if (r->error_page) {
             return NGX_DECLINED;
@@ -227,36 +288,9 @@ ngx_http_coraza_pre_access_handler(ngx_http_request_t *r)
             return ret;
         }
 
-        pret = coraza_process_request_body(ctx->coraza_transaction);
-        if (ngx_http_coraza_process_body_failed(pret))
-        {
-            /*
-             * The engine could not evaluate phase 2; no interruption is set,
-             * so the poll below would let the body through uninspected.  Fail
-             * closed rather than inspect nothing while nginx forwards the body.
-             */
-            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                "coraza: request body phase processing failed");
-            ctx->intervention_triggered = 1;
-            return NGX_HTTP_INTERNAL_SERVER_ERROR;
-        }
-
-        ret = ngx_http_coraza_poll_after_process(ctx, r, 0, pret);
-        if (r->error_page) {
-            return NGX_DECLINED;
-        }
-        if (ret < 0) {
-            /* NGX_ERROR from the intervention handler: fail closed. */
-            ctx->intervention_triggered = 1;
-            return NGX_HTTP_INTERNAL_SERVER_ERROR;
-        }
-        if (ret > 0) {
-            ctx->intervention_triggered = 1;
-            return ret;
-        }
+        return ngx_http_coraza_process_request_body_phase(ctx, r);
     }
 
     dd("Nothing to add on the body inspection, reclaiming a NGX_DECLINED");
     return NGX_DECLINED;
 }
-

--- a/t/coraza-dynlib-contract.t
+++ b/t/coraza-dynlib-contract.t
@@ -29,6 +29,12 @@ unlike($dl, qr/libcoraza\s*<\s*1\.4/,
 like($dl, qr/DL_SYM\(dl_is_response_body_processable,\s*coraza_is_response_body_processable\)/s,
 	'response-body helper is resolved as a required symbol');
 
+like($dl, qr/DL_SYM\(dl_is_request_body_accessible,\s*coraza_is_request_body_accessible\)/s,
+	'request-body helper is resolved as a required symbol');
+
+like($dl, qr/return\s+dl_is_request_body_accessible\(t\)/,
+	'request-body helper wrapper calls the resolved symbol');
+
 unlike($dl, qr/DL_SYM\([^,]+,\s*coraza_rules_merge\)/,
 	'dead coraza_rules_merge symbol is not required at startup');
 

--- a/t/coraza-request-body-access-off.t
+++ b/t/coraza-request-body-access-off.t
@@ -1,0 +1,186 @@
+#!/usr/bin/perl
+
+# Request-body fast path for SecRequestBodyAccess Off.
+#
+# The connector must not preread or submit body bytes when Coraza says they are
+# inaccessible, but it must still execute phase 2.  The first test sends only
+# one byte of a declared body and requires a phase-2 header rule to deny before
+# the rest arrives.  It fails if the connector waits for the body, and also if
+# coraza_process_request_body() is incorrectly skipped.  The other tests prove
+# that an allowed body still reaches the upstream intact and that the normal
+# body-inspection path remains active when access is on.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use IO::Select;
+use IO::Socket::INET;
+use Socket qw/ CRLF /;
+use Test::More;
+use Time::HiRes qw/ time /;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(3);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location /off {
+            coraza on;
+            coraza_rules '
+                SecRuleEngine On
+                SecRequestBodyAccess On
+                SecAction "id:700,phase:1,pass,nolog,t:none,ctl:requestBodyAccess=Off"
+                SecRule REQUEST_HEADERS:X-Phase2 "@streq blockme" "id:701,phase:2,deny,status:403,log,t:none"
+            ';
+            proxy_pass http://127.0.0.1:%%PORT_8081%%;
+        }
+
+        location /on {
+            coraza on;
+            coraza_rules '
+                SecRuleEngine On
+                SecRequestBodyAccess On
+                SecAction "id:702,phase:1,pass,nolog,t:none,ctl:requestBodyProcessor=URLENCODED"
+                SecRule REQUEST_BODY "@contains blockme" "id:703,phase:2,deny,status:403,log,t:none"
+            ';
+            proxy_pass http://127.0.0.1:%%PORT_8081%%;
+        }
+    }
+}
+EOF
+
+$t->run_daemon(\&http_daemon);
+$t->run()->waitforsocket('127.0.0.1:' . port(8081));
+
+###############################################################################
+
+like(
+	early_phase2_response(),
+	qr/^HTTP\S+ 403/,
+	'phase 2 runs without waiting for an inaccessible request body'
+);
+
+my $body = 'body reaches upstream byte-for-byte';
+like(
+	http_req_body('/off', $body, 'safe'),
+	qr/\Q$body\E\z/s,
+	'inaccessible request body is still forwarded intact'
+);
+
+like(
+	http_req_body('/on', 'x=blockme', 'safe'),
+	qr/^HTTP\S+ 403/,
+	'control: accessible request body remains inspected'
+);
+
+###############################################################################
+
+sub early_phase2_response {
+	my $client = IO::Socket::INET->new(
+		PeerAddr => '127.0.0.1:' . port(8080),
+		Proto => 'tcp',
+	) or die "connect to nginx: $!\n";
+
+	$client->autoflush(1);
+	print $client 'POST /off HTTP/1.0' . CRLF
+		. 'Host: localhost' . CRLF
+		. 'X-Phase2: blockme' . CRLF
+		. 'Content-Length: 65536' . CRLF . CRLF
+		. 'x';
+
+	my $deadline = time() + ($ENV{TEST_NGINX_TIMEOUT} // 5);
+	my $select = IO::Select->new($client);
+	my $response = '';
+	while ($response !~ /\r?\n/ && length($response) < 4096) {
+		my $remaining = $deadline - time();
+		last if $remaining <= 0;
+
+		my @ready = $select->can_read($remaining);
+		last if !@ready;
+
+		my $chunk = '';
+		my $peer = recv($client, $chunk, 4096 - length($response), 0);
+		last if !defined $peer || $chunk eq '';
+		$response .= $chunk;
+	}
+
+	close $client;
+	return $response;
+}
+
+sub http_req_body {
+	my ($uri, $body, $phase2) = @_;
+	return http(
+		'POST ' . $uri . ' HTTP/1.0' . CRLF
+		. 'Host: localhost' . CRLF
+		. 'X-Phase2: ' . $phase2 . CRLF
+		. 'Content-Type: application/x-www-form-urlencoded' . CRLF
+		. 'Content-Length: ' . length($body) . CRLF . CRLF
+		. $body
+	);
+}
+
+sub http_daemon {
+	my $server = IO::Socket::INET->new(
+		Proto => 'tcp',
+		LocalHost => '127.0.0.1:' . port(8081),
+		Listen => 5,
+		Reuse => 1,
+	) or die "create backend socket: $!\n";
+
+	local $SIG{PIPE} = 'IGNORE';
+
+	while (my $client = $server->accept()) {
+		$client->autoflush(1);
+
+		my $headers = '';
+		while (<$client>) {
+			$headers .= $_;
+			last if /^\x0d?\x0a?$/;
+		}
+
+		my $body = '';
+		if ($headers =~ /Content-Length:\s*(\d+)/i) {
+			my $need = $1;
+			while (length($body) < $need) {
+				my $chunk = '';
+				my $n = read($client, $chunk, $need - length($body));
+				last if !defined $n || $n == 0;
+				$body .= $chunk;
+			}
+		}
+
+		print $client 'HTTP/1.1 200 OK' . CRLF;
+		print $client 'Content-Length: ' . length($body) . CRLF;
+		print $client 'Connection: close' . CRLF . CRLF;
+		print $client $body;
+		close $client;
+	}
+}
+
+###############################################################################


### PR DESCRIPTION
> Follow-up to [#92](https://github.com/corazawaf/coraza-nginx/pull/92). This consumes the request-side gate proposed in [corazawaf/libcoraza#118](https://github.com/corazawaf/libcoraza/issues/118) and shipped by [corazawaf/libcoraza#119](https://github.com/corazawaf/libcoraza/pull/119).

## TL;DR

When request-body inspection is disabled, the connector currently reads and copies the entire body before handing it to libcoraza, which discards it. This change lets nginx leave that body for the eventual content handler while rules scheduled after request headers are still evaluated.

In code terms, the pre-access handler now checks `coraza_is_request_body_accessible()` before requesting the body. A false result skips only nginx prereading and body submission; it still calls `coraza_process_request_body()` so phase 2 rules on non-body variables run.

**Severity:** Low (performance: avoidable request buffering, copies, and C/Go crossings when request-body access is off)

## Mechanism

- Resolve the libcoraza 1.7 request-body predicate as a required dynamic symbol. The connector already requires libcoraza 1.7, so this does not raise the dependency floor.
- Keep the existing accessible-body path unchanged, including asynchronous reads, file-backed bodies, body-limit interventions, and phase 2 processing.
- Extract the common phase 2 completion path so both accessible and inaccessible requests preserve intervention and fail-closed behavior.

## Tests

- Added an integration test that disables request-body access in phase 1, sends only one byte of a declared 64 KiB body, and requires a phase 2 header rule to respond before the rest arrives.
- The same test verifies that an inaccessible body reaches the upstream byte-for-byte and that an accessible body remains inspected.
- Added dynamic-loader contract coverage for mandatory symbol resolution and wrapper dispatch.
- Inverting the new predicate made the regression test fail its early-response and accessible-body control assertions.
- Built with nginx 1.31.3, libcoraza 1.7.0, `-Werror`, `-Wall`, and `-Wextra`.
- Full Coraza test suite: 61 files, 532 assertions passed; existing capability guards skipped HTTP/3 and one build-tree-only check.

## Performance

This removes connector-side request-body prereading and libcoraza submission when the transaction marks the body inaccessible. No throughput benchmark is included; the improvement is the removal of those operations from the disabled path.

## Security

Phase 2 is deliberately retained. Rules using request headers, URI arguments, or other non-body variables continue to run even when request-body bytes are unavailable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests with request-body inspection disabled are no longer delayed while waiting for an inaccessible body.
  * Security rules continue evaluating headers, URI arguments, and other non-body request data.
  * Allowed request bodies continue reaching the upstream service intact.
  * Request-body inspection remains available when enabled.

* **Tests**
  * Added coverage for request-body access behavior and dynamic library integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->