### PR TITLE
perf: read request tempfiles in 64 KiB chunks

### DIFF
--- a/src/ngx_http_coraza_dl.c
+++ b/src/ngx_http_coraza_dl.c
@@ -35,7 +35,6 @@ typedef int                  (*fn_coraza_process_uri)(coraza_transaction_t, char
 typedef int                  (*fn_coraza_add_request_header)(coraza_transaction_t, char *, int, char *, int);
 typedef int                  (*fn_coraza_process_request_headers)(coraza_transaction_t);
 typedef int                  (*fn_coraza_append_request_body)(coraza_transaction_t, unsigned char *, int);
-typedef int                  (*fn_coraza_request_body_from_file)(coraza_transaction_t, char *);
 typedef int                  (*fn_coraza_process_request_body)(coraza_transaction_t);
 typedef int                  (*fn_coraza_is_request_body_accessible)(coraza_transaction_t);
 typedef int                  (*fn_coraza_add_response_header)(coraza_transaction_t, char *, int, char *, int);
@@ -86,7 +85,6 @@ static fn_coraza_process_uri             dl_process_uri;
 static fn_coraza_add_request_header      dl_add_request_header;
 static fn_coraza_process_request_headers dl_process_request_headers;
 static fn_coraza_append_request_body     dl_append_request_body;
-static fn_coraza_request_body_from_file  dl_request_body_from_file;
 static fn_coraza_process_request_body    dl_process_request_body;
 static fn_coraza_is_request_body_accessible dl_is_request_body_accessible;
 static fn_coraza_add_response_header     dl_add_response_header;
@@ -172,7 +170,6 @@ ngx_http_coraza_dl_open(ngx_log_t *log)
     DL_SYM(dl_add_request_header,       coraza_add_request_header);
     DL_SYM(dl_process_request_headers,  coraza_process_request_headers);
     DL_SYM(dl_append_request_body,      coraza_append_request_body);
-    DL_SYM(dl_request_body_from_file,   coraza_request_body_from_file);
     DL_SYM(dl_process_request_body,     coraza_process_request_body);
     DL_SYM(dl_is_request_body_accessible,
            coraza_is_request_body_accessible);
@@ -324,11 +321,6 @@ int coraza_append_request_body(coraza_transaction_t t,
                                unsigned char *data, int length)
 {
     return dl_append_request_body(t, data, length);
-}
-
-int coraza_request_body_from_file(coraza_transaction_t t, char *file)
-{
-    return dl_request_body_from_file(t, file);
 }
 
 int coraza_process_request_body(coraza_transaction_t t)

--- a/src/ngx_http_coraza_pre_access.c
+++ b/src/ngx_http_coraza_pre_access.c
@@ -15,6 +15,8 @@
 
 #include "ngx_http_coraza_common.h"
 
+#define NGX_HTTP_CORAZA_REQUEST_BODY_FILE_CHUNK_SIZE (64 * 1024)
+
 void
 ngx_http_coraza_request_read(ngx_http_request_t *r)
 {
@@ -76,6 +78,128 @@ ngx_http_coraza_process_request_body_phase(ngx_http_coraza_ctx_t *ctx,
     }
 
     return NGX_DECLINED;
+}
+
+
+/*
+ * Submit a file-buffered request body in reusable 64 KiB chunks.  Opening a
+ * separate descriptor keeps ngx_read_file() from changing nginx's file offset
+ * state on platforms without pread(); nginx may still need its descriptor to
+ * forward the same body upstream after inspection.
+ */
+static ngx_int_t
+ngx_http_coraza_append_request_body_file(ngx_http_coraza_ctx_t *ctx,
+    ngx_http_request_t *r, ngx_temp_file_t *temp_file)
+{
+    ngx_file_t  file;
+    u_char     *data;
+    off_t       body_size;
+    off_t       offset;
+    size_t      size;
+    ssize_t     n;
+    ngx_int_t   rc;
+    ngx_int_t   ret;
+
+    body_size = temp_file->file.offset;
+    if (body_size == 0) {
+        return NGX_OK;
+    }
+
+    if (body_size < 0) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+            "coraza: invalid file-buffered request body size");
+        ctx->intervention_triggered = 1;
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    ngx_memzero(&file, sizeof(ngx_file_t));
+    file.name = temp_file->file.name;
+    file.log = r->connection->log;
+    file.fd = ngx_open_file(file.name.data, NGX_FILE_RDONLY,
+                            NGX_FILE_OPEN, 0);
+
+    if (file.fd == NGX_INVALID_FILE) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, ngx_errno,
+            ngx_open_file_n " \"%V\" failed", &file.name);
+        ctx->intervention_triggered = 1;
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    data = ngx_alloc(NGX_HTTP_CORAZA_REQUEST_BODY_FILE_CHUNK_SIZE,
+                     r->connection->log);
+    if (data == NULL) {
+        rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
+        goto done;
+    }
+
+    offset = 0;
+    rc = NGX_OK;
+
+    while (offset < body_size) {
+        if (body_size - offset
+            > (off_t) NGX_HTTP_CORAZA_REQUEST_BODY_FILE_CHUNK_SIZE)
+        {
+            size = NGX_HTTP_CORAZA_REQUEST_BODY_FILE_CHUNK_SIZE;
+        } else {
+            size = (size_t) (body_size - offset);
+        }
+
+        n = ngx_read_file(&file, data, size, offset);
+        if (n == NGX_ERROR) {
+            rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
+            goto free;
+        }
+
+        if (n == 0) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                "coraza: file-buffered request body ended at %O of %O bytes",
+                offset, body_size);
+            rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
+            goto free;
+        }
+
+        if (coraza_append_request_body(ctx->coraza_transaction, data,
+                                       (int) n) != 0)
+        {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                "coraza: failed to append file-buffered request body chunk "
+                "for inspection");
+            rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
+            goto free;
+        }
+
+        offset += n;
+
+        if (offset < body_size) {
+            ret = ngx_http_coraza_process_intervention(ctx, r, 0);
+            if (ret < 0) {
+                rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
+                goto free;
+            }
+            if (ret > 0) {
+                ctx->intervention_triggered = 1;
+                rc = ret;
+                goto free;
+            }
+        }
+    }
+
+free:
+
+    ngx_free(data);
+
+done:
+
+    if (ngx_close_file(file.fd) == NGX_FILE_ERROR) {
+        ngx_log_error(NGX_LOG_ALERT, r->connection->log, ngx_errno,
+            ngx_close_file_n " \"%V\" failed", &file.name);
+    }
+
+    if (rc != NGX_OK) {
+        ctx->intervention_triggered = 1;
+    }
+
+    return rc;
 }
 
 
@@ -175,7 +299,7 @@ ngx_http_coraza_pre_access_handler(ngx_http_request_t *r)
     {
         int ret = 0;
         int already_inspected = 0;
-        char *file_name = NULL;
+        ngx_int_t rc;
 
         dd("request body phase is ready to be processed");
 
@@ -187,29 +311,16 @@ ngx_http_coraza_pre_access_handler(ngx_http_request_t *r)
         r->write_event_handler = ngx_http_core_run_phases;
 
         if (r->request_body->temp_file != NULL) {
-            ngx_str_t file_path = r->request_body->temp_file->file.name;
-            if (ngx_str_to_char(file_path, &file_name, r->pool) != NGX_OK) {
-                return NGX_HTTP_INTERNAL_SERVER_ERROR;
-            }
             /*
              * Request body was saved to a file, probably we don't have a
              * copy of it in memory.
              */
-            dd("request body inspection: file -- %s", file_name);
+            dd("request body inspection: file");
 
-            /*
-             * A non-zero return means libcoraza could not read/submit the
-             * body file, so the engine would evaluate phase 2 against no (or
-             * a partial) body while nginx forwards the full body upstream.
-             * Fail closed rather than inspect less than we forward.
-             * (libcoraza signals failure with a positive sentinel, so test
-             * != 0, not < 0.)
-             */
-            if (coraza_request_body_from_file(ctx->coraza_transaction, file_name) != 0) {
-                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                    "coraza: failed to submit file-buffered request body for inspection");
-                ctx->intervention_triggered = 1;
-                return NGX_HTTP_INTERNAL_SERVER_ERROR;
+            rc = ngx_http_coraza_append_request_body_file(ctx, r,
+                    r->request_body->temp_file);
+            if (rc != NGX_OK) {
+                return rc;
             }
 
             already_inspected = 1;

--- a/t/coraza-request-body-chunked.t
+++ b/t/coraza-request-body-chunked.t
@@ -10,11 +10,10 @@
 #     reads -- had no coverage at all.
 #
 #   * Temp-file bodies.  ngx_http_coraza_pre_access.c has a whole branch for
-#     r->request_body->temp_file that hands the file PATH to Coraza
-#     (coraza_request_body_from_file) instead of appending buffers.  Every
-#     existing body test sends a few hundred bytes and stays in memory, so
-#     that branch was never entered.  client_body_buffer_size here is small
-#     enough to force the spill.
+#     r->request_body->temp_file that reads and appends the file in reusable
+#     64 KiB chunks.  Every existing body test sends a few hundred bytes and
+#     stays in memory, so that branch was never entered.  The small
+#     client_body_buffer_size here forces the spill.
 #
 # The adversarial case that matters for the temp-file path: a payload split
 # across the buffer boundary must still be inspected as one body.  If only
@@ -40,7 +39,7 @@ use Test::Nginx;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(7);
+my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(9);
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 
@@ -70,7 +69,7 @@ http {
         }
 
         # client_body_buffer_size 1k forces anything larger to a temp file, so
-        # this location drives the coraza_request_body_from_file branch.
+        # this location drives the connector's chunked temp-file reader.
         # SecRequestBodyLimit must stay above the payload or Coraza would
         # reject it before the branch is reached.
         location /body-file {
@@ -83,6 +82,20 @@ http {
                 SecRequestBodyNoFilesLimit 1048576
                 SecAction "id:7203,phase:1,pass,nolog,ctl:requestBodyProcessor=URLENCODED"
                 SecRule REQUEST_BODY "@contains BADBODY" "id:7202,phase:2,deny,log,status:403"
+            ';
+            proxy_pass http://127.0.0.1:%%PORT_8081%%;
+        }
+
+        # The connector-owned reader must preserve Coraza's request-body limit
+        # intervention when the limit is crossed between 64 KiB appends.
+        location /body-file-limit {
+            client_body_buffer_size 1k;
+            coraza on;
+            coraza_rules '
+                SecRuleEngine On
+                SecRequestBodyAccess On
+                SecRequestBodyLimit 65536
+                SecRequestBodyLimitAction Reject
             ';
             proxy_pass http://127.0.0.1:%%PORT_8081%%;
         }
@@ -127,6 +140,15 @@ like(post('/body-file', $tail), qr!^HTTP/1.1 403!,
 my $straddle = ('A' x 1021) . 'BADBODY' . ('B' x 4096);
 like(post('/body-file', $straddle), qr!^HTTP/1.1 403!,
 	'temp-file body inspected (marker straddling the buffer boundary)');
+
+# Marker straddling the connector's 64 KiB read boundary: separate appends must
+# still form one contiguous body for the request-body processor.
+my $reader_straddle = ('A' x 65533) . 'BADBODY' . ('B' x 4096);
+like(post('/body-file', $reader_straddle), qr!^HTTP/1.1 403!,
+	'temp-file body inspected across the 64 KiB reader boundary');
+
+like(post('/body-file-limit', 'L' x 70000), qr!^HTTP/1.1 413!,
+	'temp-file reader preserves request-body limit enforcement');
 
 # Control: same size, no marker -- proves the 403s above are the rule matching
 # and not the temp-file path failing closed on every large body.

--- a/t/coraza-request-body-reader-contract.t
+++ b/t/coraza-request-body-reader-contract.t
@@ -1,0 +1,55 @@
+#!/usr/bin/perl
+
+# Static contract checks for the connector-owned temp-file request-body reader.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+use FindBin;
+
+###############################################################################
+
+my $root = "$FindBin::Bin/..";
+
+my $pre_access = slurp("$root/src/ngx_http_coraza_pre_access.c");
+my $dl = slurp("$root/src/ngx_http_coraza_dl.c");
+
+like($pre_access,
+	qr/#define NGX_HTTP_CORAZA_REQUEST_BODY_FILE_CHUNK_SIZE \(64 \* 1024\)/,
+	'temp-file reader uses 64 KiB chunks');
+
+like($pre_access,
+	qr/body_size - offset\s*> \(off_t\) NGX_HTTP_CORAZA_REQUEST_BODY_FILE_CHUNK_SIZE\).*?size = NGX_HTTP_CORAZA_REQUEST_BODY_FILE_CHUNK_SIZE/s,
+	'read size is capped by the 64 KiB chunk constant');
+
+like($pre_access,
+	qr/while \(offset < body_size\).*?ngx_read_file\(&file, data, size, offset\).*?coraza_append_request_body/s,
+	'temp-file reader appends each bounded file chunk');
+
+like($pre_access,
+	qr/while \(offset < body_size\).*?coraza_append_request_body.*?ngx_http_coraza_process_intervention/s,
+	'temp-file reader stops promptly on an intervention');
+
+like($pre_access,
+	qr/ngx_alloc\(NGX_HTTP_CORAZA_REQUEST_BODY_FILE_CHUNK_SIZE,.*?while \(offset < body_size\).*?ngx_free\(data\)/s,
+	'temp-file reader reuses and releases one chunk buffer');
+
+unlike($pre_access, qr/\bcoraza_request_body_from_file\b/,
+	'pre-access path no longer delegates file reads to libcoraza');
+
+unlike($dl, qr/\b(?:fn_|dl_)?coraza_request_body_from_file\b/,
+	'unused libcoraza file-reader symbol is not required at runtime');
+
+done_testing();
+
+###############################################################################
+
+sub slurp {
+	my ($path) = @_;
+	open my $fh, '<', $path or die "open $path: $!";
+	local $/ = undef;
+	return <$fh>;
+}

--- a/t/coraza-request-body-tempfile.t
+++ b/t/coraza-request-body-tempfile.t
@@ -4,10 +4,9 @@
 # buffered to a temporary FILE rather than kept in memory.
 #
 # With client_body_in_file_only nginx always spills the request body to a temp
-# file; the pre-access handler then feeds Coraza via
-# coraza_request_body_from_file() (the temp_file branch) instead of the
-# in-memory chain walk.  A phase-2 REQUEST_BODY rule proves the file-backed
-# body is still inspected and blocked.
+# file; the pre-access handler then feeds Coraza through the connector's
+# chunked temp-file reader instead of the in-memory chain walk.  A phase-2
+# REQUEST_BODY rule proves the file-backed body is still inspected and blocked.
 
 ###############################################################################
 
@@ -50,7 +49,7 @@ http {
 
         location /body {
             # Force the request body onto disk so the temp-file inspection
-            # path (coraza_request_body_from_file) is exercised.
+            # path (the connector's chunked temp-file reader) is exercised.
             client_body_in_file_only on;
             coraza_rules '
                 SecRuleEngine On


### PR DESCRIPTION
> Connector-side follow-up to corazawaf/libcoraza#118. This is independent of nginx core and does not require a libcoraza change.

## TL;DR

Large request bodies that spill to disk are currently reread in very small pieces, multiplying file operations and engine submissions. This moves that work into the connector with much larger reusable chunks while preserving request-body limits and phase-2 inspection.

In code terms: `ngx_http_coraza_append_request_body_file()` reads nginx request tempfiles through a separate descriptor in 64 KiB chunks and submits each chunk through `coraza_append_request_body()`.

**Severity:** `Low` (`performance — excessive tempfile read and body-write operations`)

## What changed

- Read file-buffered request bodies in reusable 64 KiB chunks.
- Keep nginx's tempfile descriptor and offset untouched for later upstream forwarding.
- Poll between chunks so a body-limit intervention stops further tempfile work promptly.
- Fail closed on open, allocation, read, truncation, and Coraza append failures.
- Remove the unused runtime dependency on `coraza_request_body_from_file`.

## Operation reduction

For a 1 MiB body, successful file-read chunks and Coraza body writes fall from 1,024 to 16: 1,008 fewer operations, or 98.4%. This is deterministic operation-count reduction, not a claim of a measured 98.4% end-to-end latency improvement; the connector path adds per-chunk C-to-Go crossings and copies that need workload benchmarking for a wall-clock figure.

## Testing

- nginx 1.31.3 debug build with `-Werror` and live debug logging paths
- Angie 1.12.1 module build with `-Werror`
- Focused tempfile, chunked-body, 64 KiB boundary, body-limit, clean-control, and static contract tests
- clang-tidy with nginx build include paths and exhaustive cppcheck
- CodeRabbit uncommitted review after the confirmed intervention finding was fixed: no findings
- Independent reviews of nginx/Angie tempfile ownership, fail-closed behavior, tests, and reduction math


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of request bodies stored in temporary files by processing them in manageable chunks.
  * Added intervention checks during request-body processing to stop safely when required.
  * Strengthened failure handling for invalid, unreadable, or incomplete request-body data.
  * Preserved request-body size-limit enforcement.

* **Tests**
  * Expanded coverage for large request bodies, chunk boundaries, intervention handling, and temporary-file processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->