### PR TITLE
fix: reject ruleless Coraza enablement

### DIFF
--- a/src/ngx_http_coraza_module.c
+++ b/src/ngx_http_coraza_module.c
@@ -24,6 +24,7 @@ static void *ngx_http_coraza_create_main_conf(ngx_conf_t *cf);
 static char *ngx_http_coraza_init_main_conf(ngx_conf_t *cf, void *conf);
 static void *ngx_http_coraza_create_conf(ngx_conf_t *cf);
 static char *ngx_http_coraza_merge_conf(ngx_conf_t *cf, void *parent, void *child);
+static ngx_int_t ngx_http_coraza_validate_rules(ngx_conf_t *cf);
 static ngx_int_t ngx_http_coraza_init_process(ngx_cycle_t *cycle);
 static void ngx_http_coraza_exit_process(ngx_cycle_t *cycle);
 
@@ -428,6 +429,10 @@ ngx_http_coraza_init(ngx_conf_t *cf)
 	ngx_http_core_main_conf_t *cmcf;
 	int rc = 0;
 
+	if (ngx_http_coraza_validate_rules(cf) != NGX_OK) {
+		return NGX_ERROR;
+	}
+
 	cmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_core_module);
 	if (cmcf == NULL)
 	{
@@ -476,6 +481,45 @@ ngx_http_coraza_init(ngx_conf_t *cf)
 	}
 
 	return NGX_OK;
+}
+
+static ngx_int_t
+ngx_http_coraza_validate_rules(ngx_conf_t *cf)
+{
+	ngx_http_coraza_main_conf_t *mmcf;
+	ngx_http_coraza_conf_t *lcf;
+	ngx_http_coraza_conf_t **loc_confs;
+	ngx_uint_t i;
+
+	mmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_coraza_module);
+	if (mmcf == NULL || mmcf->rules_inline != 0 || mmcf->rules_file != 0) {
+		return NGX_OK;
+	}
+
+	lcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_coraza_module);
+	if (lcf != NULL && lcf->enable == 1) {
+		goto ruleless;
+	}
+
+	if (mmcf->loc_confs == NULL) {
+		return NGX_OK;
+	}
+
+	loc_confs = mmcf->loc_confs->elts;
+	for (i = 0; i < mmcf->loc_confs->nelts; i++) {
+		lcf = loc_confs[i];
+		if (lcf->enable == 1) {
+			goto ruleless;
+		}
+	}
+
+	return NGX_OK;
+
+ruleless:
+	ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+				  "coraza: \"coraza on\" requires at least one "
+				  "inherited or configured rule");
+	return NGX_ERROR;
 }
 
 static void *

--- a/t/coraza-http-level-rules.t
+++ b/t/coraza-http-level-rules.t
@@ -28,6 +28,7 @@ select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
 my $t = Test::Nginx->new()->has(qw/http/);
+my $nginx = defined $ENV{TEST_NGINX_BINARY} ? $ENV{TEST_NGINX_BINARY} : 'nginx';
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 
@@ -76,7 +77,7 @@ EOF
 
 $t->run();
 $t->todo_alerts();
-$t->plan(3);
+$t->plan(5);
 
 ###############################################################################
 
@@ -92,3 +93,35 @@ like(http_get('/inherited?block=0'), qr/^HTTP.*200/,
 like(http_get('/off?block=1', PeerAddr => '127.0.0.1:' . port(8081)),
     qr/^HTTP.*200/,
     'coraza off does not enforce inherited http-level rules (control)');
+
+my $testdir = $t->testdir();
+
+$t->write_file_expand('ruleless.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    access_log off;
+
+    server {
+        listen 127.0.0.1:%%PORT_8082%%;
+
+        location / {
+            coraza on;
+            return 200 "unprotected";
+        }
+    }
+}
+EOF
+
+my $out = `$nginx -t -p $testdir/ -c ruleless.conf 2>&1`;
+my $rc = $?;
+
+isnt($rc, 0, 'nginx rejects coraza on when the http block declares no rules at all');
+like($out, qr/"coraza on" requires at least one inherited or configured rule/,
+    'ruleless coraza configuration reports the fail-closed error');

--- a/t/coraza-transaction-id-args.t
+++ b/t/coraza-transaction-id-args.t
@@ -48,6 +48,7 @@ http {
     %%TEST_GLOBALS_HTTP%%
 
     coraza_transaction_id "tid-A";
+    coraza_rules 'SecRuleEngine On';
 
     server {
         listen       127.0.0.1:8080;


### PR DESCRIPTION
## TL;DR

You can currently switch the firewall on without giving it a single rule to enforce. Nginx starts, requests flow, and the setting looks active while nothing is actually being checked. This makes that configuration fail at startup instead of quietly doing nothing.

In code terms: `ngx_http_coraza_validate_rules()` runs during postconfiguration and rejects an enabled `coraza on` when the `http` block declares no `coraza_rules` or `coraza_rules_file` anywhere.

**Severity:** `High` (`security configuration - an enabled but ruleless WAF silently allowed every request`)

## What changed

- Postconfiguration walks the merged location configurations and raises an emergency configuration error when one has `coraza on` with no rules loaded anywhere. `nginx -t` and startup both fail before workers fork.
- The check reads configuration state only. Loading `libcoraza` stays in `init_process`, after the fork.
- `t/coraza-http-level-rules.t` keeps its existing inheritance checks and adds a ruleless config that must fail with the new diagnostic.

## Scope, and what this deliberately does not catch

The validator only fires when the entire `http` block contains no rule directives. If any scope loads rules, the check stands down for the whole configuration.

That leaves a real gap: with `server A` loading rules and `server B { location / { coraza on; } }` inheriting none, B still starts and enforces nothing, because `init_process` skips building a WAF for a location whose `has_rules` is zero. Catching that needs a per-scope rule, which would reject the established layout of enabling Coraza at server level and attaching rules in child locations. That is a compatibility decision with its own regression matrix, so I left it out rather than smuggle it in here.

The added test is named for what it actually proves, the zero-rules-anywhere case, not the broader guarantee.

## Compatibility

This tightens one contract: `coraza on` is invalid when no rule directives exist anywhere in its `http` block. Server-level enable with child-location rules keeps working, as do the existing http/server/location inheritance paths.

`t/coraza-transaction-id-args.t` needed a rule added to its config to keep passing, which is a fair signal of the blast radius: anyone running `coraza on` with rules supplied through a path the module does not count will now hit a hard failure at `nginx -t`.

## Testing

`t/coraza-http-level-rules.t` covers the ruleless config: `nginx -t` must exit non-zero and print the new diagnostic, alongside the existing positive inheritance and negative-control cases. The rule added to `t/coraza-transaction-id-args.t` keeps that suite valid under the tightened contract.

I have not run the full prove suite against a built module in this session, so I am not claiming a local black-box pass; CI provides the build and runtime coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Nginx now rejects configurations that enable Coraza without any configured rules, preventing startup with an ineffective security configuration.
  - Invalid configurations fail closed with an emergency error during validation.

- **Tests**
  - Added coverage for ruleless Coraza configurations and configuration validation failures.
  - Updated transaction ID argument coverage to include a valid Coraza rule configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->