### PR TITLE
perf: bound file-backed response inspection

### DIFF
--- a/src/ngx_http_coraza_body_filter.c
+++ b/src/ngx_http_coraza_body_filter.c
@@ -12,6 +12,8 @@
 
 static ngx_http_output_body_filter_pt ngx_http_next_body_filter;
 
+#define NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE (64 * 1024)
+
 /*
  * Length of the body data ngx_http_coraza_read_body_data would return,
  * without performing the read/allocation -- lets callers reject an
@@ -105,6 +107,126 @@ ngx_http_coraza_read_body_data(ngx_http_request_t *r, ngx_buf_t *buf,
 }
 
 
+/*
+ * Submit a file-backed response range through one reusable scratch buffer.
+ * File buffers can describe an arbitrarily large range, so allocating the
+ * whole range in r->pool would retain that allocation until request teardown.
+ */
+static ngx_int_t
+ngx_http_coraza_append_response_body_file(ngx_http_coraza_ctx_t *ctx,
+    ngx_http_request_t *r, ngx_buf_t *buf)
+{
+    u_char    *data;
+    off_t      offset;
+    size_t     size;
+    ssize_t    n;
+    ngx_int_t  rc;
+#if (NGX_HAVE_ALIGNED_DIRECTIO)
+    ngx_uint_t directio_disabled;
+#endif
+
+    if (buf->file_last < buf->file_pos) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+            "coraza: invalid file-backed response body range");
+        ctx->intervention_triggered = 1;
+        return NGX_ERROR;
+    }
+
+    if (buf->file_last == buf->file_pos) {
+        return NGX_OK;
+    }
+
+    data = ngx_alloc(NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE,
+                     r->connection->log);
+    if (data == NULL) {
+        ctx->intervention_triggered = 1;
+        return NGX_ERROR;
+    }
+
+    offset = buf->file_pos;
+    rc = NGX_OK;
+
+#if (NGX_HAVE_ALIGNED_DIRECTIO)
+    directio_disabled = 0;
+
+    if (buf->file->directio) {
+        if (ngx_directio_off(buf->file->fd) == NGX_FILE_ERROR) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, ngx_errno,
+                ngx_directio_off_n " \"%s\" failed", buf->file->name.data);
+            rc = NGX_ERROR;
+            goto done;
+        }
+
+        directio_disabled = 1;
+    }
+#endif
+
+    while (offset < buf->file_last) {
+        if (buf->file_last - offset
+            > (off_t) NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE)
+        {
+            size = NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE;
+        } else {
+            size = (size_t) (buf->file_last - offset);
+        }
+
+        n = ngx_read_file(buf->file, data, size, offset);
+        if (n == NGX_ERROR) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, ngx_errno,
+                "coraza: failed to read file-backed response body at %O",
+                offset);
+            rc = NGX_ERROR;
+            break;
+        }
+
+        if (n == 0) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                "coraza: file-backed response body ended at %O of %O bytes",
+                offset, buf->file_last);
+            rc = NGX_ERROR;
+            break;
+        }
+
+        if (coraza_append_response_body(ctx->coraza_transaction, data,
+                                        (int) n) != 0)
+        {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                "coraza: failed to append file-backed response body chunk "
+                "for inspection");
+            rc = NGX_ERROR;
+            break;
+        }
+
+        offset += n;
+    }
+
+#if (NGX_HAVE_ALIGNED_DIRECTIO)
+done:
+
+    if (directio_disabled) {
+        ngx_err_t  err;
+
+        err = ngx_errno;
+
+        if (ngx_directio_on(buf->file->fd) == NGX_FILE_ERROR) {
+            ngx_log_error(NGX_LOG_ALERT, r->connection->log, ngx_errno,
+                ngx_directio_on_n " \"%s\" failed", buf->file->name.data);
+        }
+
+        ngx_set_errno(err);
+    }
+#endif
+
+    ngx_free(data);
+
+    if (rc != NGX_OK) {
+        ctx->intervention_triggered = 1;
+    }
+
+    return rc;
+}
+
+
 ngx_int_t
 ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 {
@@ -164,44 +286,13 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
             size_t  len;
             int     ret;
 
-            /*
-             * coraza_append_response_body takes an int length; guard the
-             * size_t -> int narrowing so a >INT_MAX buffer cannot wrap to a
-             * bogus length and skip inspection. Fail closed. Checked against
-             * the buffer's own bounds before the read/allocation below, so
-             * an oversized on-disk chunk is rejected without paying for the
-             * file read first.
-             */
-            if (ngx_http_coraza_body_chunk_len(chain->buf) > INT_MAX) {
-                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                    "coraza: response body chunk too large to inspect");
-                ctx->intervention_triggered = 1;
-                return NGX_ERROR;
-            }
-
-            if (ngx_http_coraza_read_body_data(r, chain->buf, &data, &len)
-                != NGX_OK)
+            if (!ngx_buf_in_memory(chain->buf)
+                && chain->buf->in_file
+                && chain->buf->file)
             {
-                return NGX_ERROR;
-            }
-
-            if (len > 0) {
-                /*
-                 * A non-zero return means libcoraza could not write the
-                 * chunk into the response-body buffer, so the engine would
-                 * evaluate phase 4 against a shorter body than nginx streams
-                 * to the client -- an inspection bypass. Fail closed, exactly
-                 * as the request-body append path does. Matches the libcoraza
-                 * contract where coraza_append_response_body() returns 1 on a
-                 * WriteResponseBody error and 0 on success.
-                 */
-                if (coraza_append_response_body(ctx->coraza_transaction,
-                                                data, len) != 0)
+                if (ngx_http_coraza_append_response_body_file(ctx, r,
+                        chain->buf) != NGX_OK)
                 {
-                    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                        "coraza: failed to append response body chunk "
-                        "for inspection");
-                    ctx->intervention_triggered = 1;
                     if (ctx->headers_delayed) {
                         ctx->headers_delayed = 0;
                         return NGX_HTTP_INTERNAL_SERVER_ERROR;
@@ -209,6 +300,43 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                     return ngx_http_filter_finalize_request(r,
                         &ngx_http_coraza_module,
                         NGX_HTTP_INTERNAL_SERVER_ERROR);
+                }
+
+            } else {
+                /*
+                 * In-memory data still crosses an int-length cgo boundary.
+                 * File ranges use bounded chunks above and never narrow the
+                 * complete logical range.
+                 */
+                if (ngx_http_coraza_body_chunk_len(chain->buf) > INT_MAX) {
+                    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                        "coraza: response body chunk too large to inspect");
+                    ctx->intervention_triggered = 1;
+                    return NGX_ERROR;
+                }
+
+                if (ngx_http_coraza_read_body_data(r, chain->buf, &data, &len)
+                    != NGX_OK)
+                {
+                    return NGX_ERROR;
+                }
+
+                if (len > 0) {
+                    if (coraza_append_response_body(ctx->coraza_transaction,
+                                                    data, len) != 0)
+                    {
+                        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                            "coraza: failed to append response body chunk "
+                            "for inspection");
+                        ctx->intervention_triggered = 1;
+                        if (ctx->headers_delayed) {
+                            ctx->headers_delayed = 0;
+                            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+                        }
+                        return ngx_http_filter_finalize_request(r,
+                            &ngx_http_coraza_module,
+                            NGX_HTTP_INTERNAL_SERVER_ERROR);
+                    }
                 }
             }
 
@@ -317,18 +445,18 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                 u_char    *data;
                 size_t     len;
 
-                if (!ctx->response_body_processable
-                    && !ngx_buf_in_memory(chain->buf)
+                if (!ngx_buf_in_memory(chain->buf)
                     && chain->buf->in_file
                     && chain->buf->file != NULL
                     && !chain->buf->temp_file)
                 {
                     /*
-                     * No body inspection will read these bytes.  Pure
-                     * non-temp file-backed buffers can be replayed by
+                     * Pure non-temp file-backed buffers can be replayed by
                      * preserving the stable file range instead of reading it
-                     * into r->pool.  Upstream temp files keep the copy path
-                     * because their lifetime is controlled by upstream.
+                     * into r->pool.  Inspection, when enabled, already read
+                     * the range through a bounded scratch buffer above.
+                     * Upstream temp files keep the copy path because their
+                     * lifetime is controlled by upstream.
                      */
                     b = ngx_calloc_buf(r->pool);
                     if (b == NULL) {
@@ -350,10 +478,9 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                      * the cap never tripped.  Charge the logical range so the
                      * cap governs this path too: once past it the headers and
                      * everything buffered so far are flushed and the remainder
-                     * streams through.  There is no cost to clean phase-4
-                     * blocking here -- body inspection is disabled for this
-                     * transaction (!response_body_processable), so the delay
-                     * is only holding headers, not enabling a body block.
+                     * streams through.  Under the cap, the delay still holds
+                     * these stable ranges until phase 4 completes, whether or
+                     * not response-body inspection is enabled.
                      */
                     ctx->pending_bytes +=
                         (size_t) (chain->buf->file_last - chain->buf->file_pos);

--- a/t/coraza-delayed-file-buffer.t
+++ b/t/coraza-delayed-file-buffer.t
@@ -29,8 +29,8 @@ my $src = slurp("$root/src/ngx_http_coraza_body_filter.c");
 my $t = Test::Nginx->new()->has(qw/http/)->plan(12);
 
 like($src,
-    qr/!\s*ctx->response_body_processable\s*&&\s*!\s*ngx_buf_in_memory\(chain->buf\)\s*&&\s*chain->buf->in_file\s*&&\s*chain->buf->file\s*!=\s*NULL\s*&&\s*!\s*chain->buf->temp_file.*?\*b\s*=\s*\*chain->buf/s,
-    'uninspected non-temp file-backed delayed buffers are cloned without body copy');
+    qr/!\s*ngx_buf_in_memory\(chain->buf\)\s*&&\s*chain->buf->in_file\s*&&\s*chain->buf->file\s*!=\s*NULL\s*&&\s*!\s*chain->buf->temp_file.*?\*b\s*=\s*\*chain->buf/s,
+    'non-temp file-backed delayed buffers are cloned without body copy');
 
 like($src,
     qr/\*b\s*=\s*\*chain->buf;.*?chain->buf->file_pos\s*=\s*chain->buf->file_last/s,

--- a/t/coraza-response-body-file-reader-contract.t
+++ b/t/coraza-response-body-file-reader-contract.t
@@ -1,0 +1,53 @@
+#!/usr/bin/perl
+
+# Static contract checks for bounded file-backed response-body inspection.
+
+use warnings;
+use strict;
+
+use Test::More;
+use FindBin;
+
+my $root = "$FindBin::Bin/..";
+my $body_filter = slurp("$root/src/ngx_http_coraza_body_filter.c");
+
+like($body_filter,
+    qr/#define NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE \(64 \* 1024\)/,
+    'file-backed response inspection uses 64 KiB chunks');
+
+like($body_filter,
+    qr/file_last - offset\s*>\s*\(off_t\) NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE.*?size = NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE/s,
+    'file read size is capped before allocation and read');
+
+like($body_filter,
+    qr/ngx_alloc\(NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE,.*?while \(offset < buf->file_last\).*?ngx_read_file\(buf->file, data, size, offset\).*?coraza_append_response_body.*?ngx_free\(data\)/s,
+    'one scratch buffer is reused and released across file chunks');
+
+like($body_filter,
+    qr/if \(buf->file->directio\).*?ngx_directio_off\(buf->file->fd\).*?while \(offset < buf->file_last\).*?ngx_read_file\(buf->file, data, size, offset\).*?if \(directio_disabled\).*?ngx_directio_on\(buf->file->fd\)/s,
+    'direct I/O is disabled around reads into the reusable scratch buffer');
+
+like($body_filter,
+    qr/if \(!ngx_buf_in_memory\(chain->buf\).*?ngx_http_coraza_append_response_body_file\(ctx, r,\s*chain->buf\)/s,
+    'file-backed response buffers use the bounded reader');
+
+like($body_filter,
+    qr/ngx_http_coraza_append_response_body_file\(ctx, r,\s*chain->buf\) != NGX_OK\).*?headers_delayed = 0;.*?NGX_HTTP_INTERNAL_SERVER_ERROR.*?ngx_http_filter_finalize_request/s,
+    'file inspection failures use the normal fail-closed response path');
+
+like($body_filter,
+    qr/if \(!ngx_buf_in_memory\(chain->buf\)\s*&& chain->buf->in_file\s*&& chain->buf->file != NULL\s*&& !chain->buf->temp_file\).*?\*b = \*chain->buf/s,
+    'stable delayed file ranges are retained without a body-sized pool copy');
+
+like($body_filter,
+    qr/if \(is_last\).*?coraza_process_response_body\(ctx->coraza_transaction\)/s,
+    'last file buffer still finalizes phase-4 inspection');
+
+done_testing();
+
+sub slurp {
+    my ($path) = @_;
+    open my $fh, '<', $path or die "open $path: $!";
+    local $/ = undef;
+    return <$fh>;
+}

--- a/t/coraza-response-body.t
+++ b/t/coraza-response-body.t
@@ -59,6 +59,29 @@ http {
                 SecResponseBodyAccess Off
             ';
         }
+
+        location /body_file_clean {
+            default_type text/plain;
+            directio 512;
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess On
+                SecResponseBodyMimeType text/plain
+                SecResponseBodyLimit 524288
+            ';
+        }
+
+        location /body_file_block {
+            default_type text/plain;
+            directio 512;
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess On
+                SecResponseBodyMimeType text/plain
+                SecResponseBodyLimit 524288
+                SecRule RESPONSE_BODY "@contains END-MARKER" "id:12,phase:4,deny,log,status:403,t:none"
+            ';
+        }
     }
 }
 EOF
@@ -72,9 +95,15 @@ $t->write_file("/body1", "BAD BODY");
 my $large_body = "X" x (100 * 1024);
 $t->write_file("/body_access_off", $large_body);
 
+# Static files arrive as file-backed buffers.  Put the rule marker beyond the
+# first 64 KiB chunk so phase 4 proves all chunks were submitted.
+my $file_body = ("R" x (256 * 1024)) . "END-MARKER";
+$t->write_file("/body_file_clean", $file_body);
+$t->write_file("/body_file_block", $file_body);
+
 $t->run();
 $t->todo_alerts();
-$t->plan(3);
+$t->plan(7);
 
 ###############################################################################
 
@@ -84,3 +113,12 @@ my $r = http_get('/body_access_off');
 like($r, qr/^HTTP.*200/, 'large response with SecResponseBodyAccess Off returns 200');
 like($r, qr/\Q$large_body\E/, 'large response body delivered intact');
 
+$r = http_get('/body_file_clean');
+like($r, qr/^HTTP.*200/, 'chunked file-backed response inspection allows clean body');
+like($r, qr/\QEND-MARKER\E/, 'chunked inspected file body is delivered intact');
+
+$r = http_get('/body_file_block');
+like($r, qr/^HTTP.*403/,
+    'phase 4 blocks on a marker beyond the first file chunk');
+unlike($r, qr/\QEND-MARKER\E/,
+    'clean phase-4 block does not leak the inspected file body');


### PR DESCRIPTION
## TL;DR

When the firewall inspects a large file being sent to a client, it used to pull the whole file into memory first, so a big download meant a matching spike in memory per request. This reads the file in fixed-size pieces instead, so inspection costs the same whether the response is 100 KB or 100 MB.

In code terms: `ngx_http_coraza_append_response_body_file()` reads file-backed response ranges through one reusable 64 KiB scratch buffer, and delayed stable file ranges keep their nginx file descriptors instead of being copied into the request pool.

**Severity:** `Low` (`performance - large inspected file responses retained body-sized request-pool allocations`)

## What changed

- File-backed ranges are validated, read in bounded chunks, and appended to Coraza until the full range is consumed.
- Short reads, invalid ranges, allocation failures, and Coraza append failures take the existing fail-closed path.
- Stable non-temporary file buffers stay file-backed while headers are delayed. Temporary upstream files keep the copy path, because nginx owns their lifetime.

## Direct I/O

The reader hands its `ngx_alloc()` scratch buffer straight to `ngx_read_file()`. Under `directio` the underlying `pread()` wants an aligned buffer and offset, so an unaligned read fails with `EINVAL`, which this path would report as `NGX_ERROR` and turn into an intervention on a perfectly clean response.

So direct I/O is toggled off around the read and restored afterwards, preserving `ngx_errno` across the restore, the same dance `ngx_output_chain_copy_buf()` does for its own unaligned reads. The runtime cases set `directio 512` so the clean and blocked file paths both exercise that branch.

## A note on the delayed-header cap

Retaining file buffers changes what `pending_bytes` accounts for: a file-backed range now charges its logical length against the cap while costing no memory. Medium-sized static responses therefore reach the early-header-flush threshold sooner than they did when only in-memory copies counted. The behaviour is intentional, but the 256 KiB body in `t/coraza-response-body.t` sits under the cap and does not exercise it.

`ngx_read_file()` also advances `file->offset` as a side effect. That field is dead state for this buffer: `ngx_output_chain.c` never reads it and the sendfile path works from `buf->file_pos`, so downstream delivery is unaffected.

## Testing

`t/coraza-response-body-file-reader-contract.t` covers the bounded reader's contract checks. The runtime cases in `t/coraza-response-body.t` put the blocking marker past the first 64 KiB chunk and exercise the clean and blocked paths.

I did not run the full prove suite locally in this session; the deterministic lint roster reported no confirmed defect in the changed lines, and clang-tidy could not parse without the generated nginx build headers, so CI provides the compile and runtime coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inspection of large file-backed response bodies by processing them in bounded chunks, reducing memory usage.
  * Preserved fail-closed behavior when response-body inspection encounters read failures.
  * Improved delayed response handling for file-backed buffers.

* **Tests**
  * Added coverage for large response bodies spanning multiple buffers.
  * Added validation for blocking content detected beyond the first file chunk.
  * Added checks for bounded file reading, error handling, and final-buffer inspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->