### PR TITLE
fix: reject premature response file EOF

### DIFF
--- a/src/ngx_http_coraza_body_filter.c
+++ b/src/ngx_http_coraza_body_filter.c
@@ -85,7 +85,10 @@ ngx_http_coraza_read_body_data(ngx_http_request_t *r, ngx_buf_t *buf,
             }
 
             if (n == 0) {
-                break;
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                    "coraza: response body file ended at %O of %O bytes",
+                    offset, buf->file_last);
+                return NGX_ERROR;
             }
 
             total_read += (size_t) n;

--- a/t/coraza-response-file-eof.t
+++ b/t/coraza-response-file-eof.t
@@ -1,0 +1,181 @@
+#!/usr/bin/perl
+
+# Executable unit test for file-backed response reads.  The production source
+# is included directly; unused filter sections are discarded by the linker.
+
+use warnings;
+use strict;
+
+use Test::More;
+use File::Temp qw(tempdir);
+use FindBin;
+
+my $nginx = $ENV{TEST_NGINX_SOURCE};
+
+# Walk up looking for the module source tree.  CI copies t/* into an unpacked
+# nginx-tests directory and proves from there, so $FindBin::Bin/../src is the
+# workspace root rather than this repository.  Matches find_root() in
+# coraza-h3-protocol-map.t.
+sub find_root {
+    my $dir = $FindBin::Bin;
+
+    for (0 .. 4) {
+        return $dir if -f "$dir/src/ngx_http_coraza_common.h";
+        $dir = "$dir/..";
+    }
+
+    return undef;
+}
+
+my $root = find_root();
+
+# Every directory below is passed to the compiler as an -I path.  ngx_http.h
+# pulls in the v2, v3 and QUIC headers whenever those modules are configured,
+# so a tree missing any of them fails during compilation rather than skipping.
+my @needed = qw(
+    src/core
+    src/event
+    src/event/modules
+    src/event/quic
+    src/os/unix
+    src/http
+    src/http/modules
+    src/http/v2
+    src/http/v3
+    objs
+);
+
+plan skip_all => 'TEST_NGINX_SOURCE must name the nginx source tree'
+    unless defined $nginx;
+
+for my $dir (@needed) {
+    plan skip_all => "TEST_NGINX_SOURCE is missing $dir"
+        unless -d "$nginx/$dir";
+}
+
+plan skip_all => 'module source tree not found'
+    unless defined $root;
+plan skip_all => 'coraza headers not available'
+    unless -f '/usr/local/include/coraza/coraza.h';
+
+plan tests => 3;
+
+my $tmp = tempdir(CLEANUP => 1);
+my $source = "$tmp/response-file-eof.c";
+my $binary = "$tmp/response-file-eof";
+
+open my $fh, '>', $source or die "open $source: $!";
+print {$fh} <<'EOF';
+#include <stdlib.h>
+#include <string.h>
+
+#include "ngx_http_coraza_common.h"
+
+#define static
+#include "ngx_http_coraza_body_filter.c"
+#undef static
+
+static int force_eof;
+
+void *
+ngx_pnalloc(ngx_pool_t *pool, size_t size)
+{
+    (void) pool;
+    return malloc(size);
+}
+
+ssize_t
+ngx_read_file(ngx_file_t *file, u_char *buf, size_t size, off_t offset)
+{
+    (void) file;
+    (void) offset;
+
+    if (force_eof) {
+        return 0;
+    }
+
+    memset(buf, 'A', size);
+    return (ssize_t) size;
+}
+
+void
+ngx_log_error_core(ngx_uint_t level, ngx_log_t *log, ngx_err_t err,
+    const char *fmt, ...)
+{
+    (void) level;
+    (void) log;
+    (void) err;
+    (void) fmt;
+}
+
+int
+main(void)
+{
+    ngx_http_request_t  request;
+    ngx_connection_t    connection;
+    ngx_pool_t          pool;
+    ngx_log_t           log;
+    ngx_buf_t           buffer;
+    ngx_file_t          file;
+    u_char             *data;
+    size_t              len;
+
+    memset(&request, 0, sizeof(request));
+    memset(&connection, 0, sizeof(connection));
+    memset(&pool, 0, sizeof(pool));
+    memset(&log, 0, sizeof(log));
+    memset(&buffer, 0, sizeof(buffer));
+    memset(&file, 0, sizeof(file));
+
+    request.pool = &pool;
+    request.connection = &connection;
+    connection.log = &log;
+    buffer.in_file = 1;
+    buffer.file = &file;
+    buffer.file_pos = 0;
+    buffer.file_last = 18;
+
+    force_eof = 1;
+    if (ngx_http_coraza_read_body_data(&request, &buffer, &data, &len)
+        != NGX_ERROR)
+    {
+        return 1;
+    }
+
+    force_eof = 0;
+    if (ngx_http_coraza_read_body_data(&request, &buffer, &data, &len)
+        != NGX_OK || len != 18)
+    {
+        return 2;
+    }
+
+    return 0;
+}
+EOF
+close $fh or die "close $source: $!";
+
+my $cc = $ENV{CC} || 'cc';
+my @includes = map { "-I$_" } (
+    "$nginx/src/core",
+    "$nginx/src/event",
+    "$nginx/src/event/modules",
+    "$nginx/src/event/quic",
+    "$nginx/src/os/unix",
+    "$nginx/src/http",
+    "$nginx/src/http/modules",
+    "$nginx/src/http/v2",
+    "$nginx/src/http/v3",
+    "$nginx/objs",
+    '/usr/local/include',
+    "$root/src",
+);
+
+is(system($cc, '-D_GNU_SOURCE', '-O2', '-ffunction-sections', '-fdata-sections',
+          '-Werror', '-Wno-unused-function', @includes, $source,
+          '-Wl,--gc-sections', '-o', $binary), 0,
+    'compiled production response-file reader harness');
+
+is(system($binary), 0,
+    'premature file EOF fails closed and a complete file buffer succeeds');
+
+ok(-x $binary, 'focused harness is executable');


### PR DESCRIPTION
## TL;DR

If a file being sent to a client ends earlier than it claimed, the firewall was treating that short read as a normal finished response. The bytes that never arrived were never inspected, so a truncated file could slip past the checks. This rejects the response instead.

In code terms: `ngx_http_coraza_read_body_data()` returns `NGX_ERROR` when `ngx_read_file()` hits EOF before `file_last`, replacing a bare `break` that handed Coraza a short body and let it evaluate phase 4 against fewer bytes than nginx would stream.

**Severity:** `Low` (`correctness - truncated file-backed responses were accepted as complete`)

## Why fail closed

The sibling reader, `ngx_http_coraza_append_response_body_file()`, already returns `NGX_ERROR` with a near-identical message on the same condition. The two file readers now agree, which is the point: a partial read is indistinguishable from a complete one downstream, so the only safe reading of a short EOF is that inspection is incomplete.

The check cannot fire on a legitimate complete read. `n == 0` is only reachable inside `while (remaining > 0)`, and `remaining` hits zero exactly when the advertised range has been consumed, so a full read leaves the loop before the test. A genuinely empty range returns earlier still.

## Testing

`t/coraza-response-file-eof.t` compiles the production reader against the nginx headers and asserts both directions: a premature EOF fails closed, and a complete 18-byte read returns `NGX_OK` with the expected length, so an over-eager fix would be caught too.

I verified it is not vacuous. Reverting the production hunk and re-running turns assertion 2 red (`got: '256'`, the harness's return from the `!= NGX_ERROR` branch); restoring it passes all three.

The harness resolves the module source by walking up for `src/ngx_http_coraza_common.h`, matching `find_root()` in `coraza-h3-protocol-map.t`, rather than assuming a fixed relative path. It skips rather than misreports when the module tree or `coraza/coraza.h` is absent, and its guard checks every include directory the compile needs, so a partial `TEST_NGINX_SOURCE` tree skips instead of failing. I ran it both from `t/` and from a staged copy inside an unpacked `nginx-tests-*` directory, the layout CI proves from.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Response processing now reports an error when a file-backed response ends unexpectedly, preventing incomplete data from being treated as valid.

* **Tests**
  * Added coverage verifying correct handling of both premature file termination and complete response data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->