### PR TITLE
fix: finalize delayed-header responses instead of returning a bare status

### DIFF
--- a/src/ngx_http_coraza_body_filter.c
+++ b/src/ngx_http_coraza_body_filter.c
@@ -260,6 +260,7 @@ ngx_http_coraza_body_filter_finalize(ngx_http_request_t *r,
 {
     ngx_flag_t was_delayed = ctx->headers_delayed;
 
+
     if (was_delayed) {
         ctx->headers_delayed    = 0;
         ctx->pending_chain      = NULL;
@@ -274,20 +275,11 @@ ngx_http_coraza_body_filter_finalize(ngx_http_request_t *r,
      * only option left and the header filter has already handled any redirect
      * before we got here.
      *
-     * Test the intervention STATUS, not merely the presence of
-     * r->headers_out.location.  The origin response may already carry a
-     * Location of its own (an upstream 302 whose body then trips a phase-4
-     * deny); keying off the header alone would route that deny down this path
-     * and answer with a header-only 403 carrying the origin's Location instead
-     * of the configured error page.  Only these statuses are the ones
-     * ngx_http_coraza_process_intervention() installs a redirect Location for.
+     * Why the status test and not r->headers_out.location alone:
+     * ngx_http_coraza_is_redirect_status().
      */
     if (was_delayed
-        && (status == NGX_HTTP_MOVED_PERMANENTLY
-            || status == NGX_HTTP_MOVED_TEMPORARILY
-            || status == NGX_HTTP_SEE_OTHER
-            || status == NGX_HTTP_TEMPORARY_REDIRECT
-            || status == NGX_HTTP_PERMANENT_REDIRECT)
+        && ngx_http_coraza_is_redirect_status(status)
         && r->headers_out.location)
     {
         ngx_int_t rc;

--- a/src/ngx_http_coraza_body_filter.c
+++ b/src/ngx_http_coraza_body_filter.c
@@ -253,10 +253,31 @@ done:
  * re-run that either path triggers early-returns instead of re-inspecting the
  * headers we just discarded.  pending_chain's buffers live in r->pool and are
  * released with the request.
+ *
+ * The redirect exit also has to account for the chain it was handed and for
+ * every chain that follows.  Nothing between this filter and the write filter
+ * checks r->header_only, and an upstream pipe only recycles a buffer once it
+ * has been consumed.  So the current chain is marked consumed here (the pipe
+ * would otherwise wait forever for buffers that never reach r->out), and the
+ * entry guard swallows every later chain while the header-only redirect is
+ * on the wire (they would otherwise be written after it as raw origin bytes;
+ * the chunked filter happens to drop them on HTTP/1.1, the plain HTTP/1.0
+ * path does not).
  */
+static void
+ngx_http_coraza_body_filter_consume(ngx_chain_t *in)
+{
+    ngx_chain_t *cl;
+
+    for (cl = in; cl != NULL; cl = cl->next) {
+        cl->buf->pos = cl->buf->last;
+        cl->buf->file_pos = cl->buf->file_last;
+    }
+}
+
 static ngx_int_t
 ngx_http_coraza_body_filter_finalize(ngx_http_request_t *r,
-    ngx_http_coraza_ctx_t *ctx, ngx_int_t status)
+    ngx_http_coraza_ctx_t *ctx, ngx_chain_t *in, ngx_int_t status)
 {
     ngx_flag_t was_delayed = ctx->headers_delayed;
 
@@ -285,6 +306,7 @@ ngx_http_coraza_body_filter_finalize(ngx_http_request_t *r,
         ngx_int_t rc;
 
         ngx_http_coraza_prepare_redirect(r, status);
+        ngx_http_coraza_body_filter_consume(in);
 
         rc = ngx_http_coraza_forward_header(r);
         if (rc == NGX_ERROR) {
@@ -316,6 +338,16 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
     }
 
     if (ctx->intervention_triggered) {
+        /*
+         * A header-only redirect from the delayed path is already on the
+         * wire; see ngx_http_coraza_body_filter_finalize().  Swallow whatever
+         * the pipe still delivers instead of writing it after the redirect.
+         */
+        if (r->header_only) {
+            ngx_http_coraza_body_filter_consume(in);
+            return NGX_OK;
+        }
+
         return ngx_http_next_body_filter(r, in);
     }
 
@@ -365,7 +397,7 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                 if (ngx_http_coraza_append_response_body_file(ctx, r,
                         chain->buf) != NGX_OK)
                 {
-                    return ngx_http_coraza_body_filter_finalize(r, ctx,
+                    return ngx_http_coraza_body_filter_finalize(r, ctx, in,
                         NGX_HTTP_INTERNAL_SERVER_ERROR);
                 }
 
@@ -379,7 +411,7 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                     ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                         "coraza: response body chunk too large to inspect");
                     ctx->intervention_triggered = 1;
-                    return ngx_http_coraza_body_filter_finalize(r, ctx,
+                    return ngx_http_coraza_body_filter_finalize(r, ctx, in,
                         NGX_HTTP_INTERNAL_SERVER_ERROR);
                 }
 
@@ -387,7 +419,7 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                     != NGX_OK)
                 {
                     ctx->intervention_triggered = 1;
-                    return ngx_http_coraza_body_filter_finalize(r, ctx,
+                    return ngx_http_coraza_body_filter_finalize(r, ctx, in,
                         NGX_HTTP_INTERNAL_SERVER_ERROR);
                 }
 
@@ -399,7 +431,7 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                             "coraza: failed to append response body chunk "
                             "for inspection");
                         ctx->intervention_triggered = 1;
-                        return ngx_http_coraza_body_filter_finalize(r, ctx,
+                        return ngx_http_coraza_body_filter_finalize(r, ctx, in,
                             NGX_HTTP_INTERNAL_SERVER_ERROR);
                     }
                 }
@@ -408,10 +440,10 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
             ret = ngx_http_coraza_process_intervention(ctx, r, 0);
             if (ret > 0) {
                 ctx->intervention_triggered = 1;
-                return ngx_http_coraza_body_filter_finalize(r, ctx, ret);
+                return ngx_http_coraza_body_filter_finalize(r, ctx, in, ret);
             } else if (ret < 0) {
                 ctx->intervention_triggered = 1;
-                return ngx_http_coraza_body_filter_finalize(r, ctx,
+                return ngx_http_coraza_body_filter_finalize(r, ctx, in,
                     NGX_HTTP_INTERNAL_SERVER_ERROR);
             }
         }
@@ -444,18 +476,18 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                 ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                     "coraza: response body phase processing failed");
                 ctx->intervention_triggered = 1;
-                return ngx_http_coraza_body_filter_finalize(r, ctx,
+                return ngx_http_coraza_body_filter_finalize(r, ctx, in,
                     NGX_HTTP_INTERNAL_SERVER_ERROR);
             }
 
             ret = ngx_http_coraza_poll_after_process(ctx, r, 0, pret);
             if (ret > 0) {
                 ctx->intervention_triggered = 1;
-                return ngx_http_coraza_body_filter_finalize(r, ctx, ret);
+                return ngx_http_coraza_body_filter_finalize(r, ctx, in, ret);
             }
             else if (ret < 0) {
                 ctx->intervention_triggered = 1;
-                return ngx_http_coraza_body_filter_finalize(r, ctx,
+                return ngx_http_coraza_body_filter_finalize(r, ctx, in,
                     NGX_HTTP_INTERNAL_SERVER_ERROR);
             }
         }

--- a/src/ngx_http_coraza_body_filter.c
+++ b/src/ngx_http_coraza_body_filter.c
@@ -230,6 +230,83 @@ done:
 }
 
 
+/*
+ * Terminate the response with `status` from inside the body filter.
+ *
+ * Returning a bare status code from a body filter is NOT a finalize: nginx
+ * propagates it up through ngx_http_output_filter() and no header is ever
+ * written, so on the delayed path -- where by construction nothing has been
+ * sent yet -- the client would see a truncated response or a reset instead of
+ * the clean error page the delay mechanism exists to provide.
+ * ngx_http_filter_finalize_request() runs ngx_http_clean_header() +
+ * ngx_http_special_response_handler() and actually produces that page.
+ *
+ * A redirect intervention is the exception, and it is why this is not a
+ * uniform finalize.  ngx_http_coraza_process_intervention() has already
+ * installed r->headers_out.location; finalizing would build a fresh error page
+ * with fresh headers and drop it, leaving the client a 3xx with no Location.
+ * So a redirect prepares the response and forwards it through the normal
+ * filter chain, exactly as the header filter's own redirect case does.  The
+ * buffered body is dropped either way: both outcomes replace it.
+ *
+ * The caller has already set ctx->intervention_triggered, so the header-filter
+ * re-run that either path triggers early-returns instead of re-inspecting the
+ * headers we just discarded.  pending_chain's buffers live in r->pool and are
+ * released with the request.
+ */
+static ngx_int_t
+ngx_http_coraza_body_filter_finalize(ngx_http_request_t *r,
+    ngx_http_coraza_ctx_t *ctx, ngx_int_t status)
+{
+    ngx_flag_t was_delayed = ctx->headers_delayed;
+
+    if (was_delayed) {
+        ctx->headers_delayed    = 0;
+        ctx->pending_chain      = NULL;
+        ctx->pending_chain_last = &ctx->pending_chain;
+        ctx->pending_bytes      = 0;
+    }
+
+    /*
+     * Only the delayed path may forward the redirect itself: its headers have
+     * not been sent, so the prepared status and Location still reach the wire.
+     * Once headers are streaming, ngx_http_filter_finalize_request() is the
+     * only option left and the header filter has already handled any redirect
+     * before we got here.
+     *
+     * Test the intervention STATUS, not merely the presence of
+     * r->headers_out.location.  The origin response may already carry a
+     * Location of its own (an upstream 302 whose body then trips a phase-4
+     * deny); keying off the header alone would route that deny down this path
+     * and answer with a header-only 403 carrying the origin's Location instead
+     * of the configured error page.  Only these statuses are the ones
+     * ngx_http_coraza_process_intervention() installs a redirect Location for.
+     */
+    if (was_delayed
+        && (status == NGX_HTTP_MOVED_PERMANENTLY
+            || status == NGX_HTTP_MOVED_TEMPORARILY
+            || status == NGX_HTTP_SEE_OTHER
+            || status == NGX_HTTP_TEMPORARY_REDIRECT
+            || status == NGX_HTTP_PERMANENT_REDIRECT)
+        && r->headers_out.location)
+    {
+        ngx_int_t rc;
+
+        ngx_http_coraza_prepare_redirect(r, status);
+
+        rc = ngx_http_coraza_forward_header(r);
+        if (rc == NGX_ERROR) {
+            return NGX_ERROR;
+        }
+
+        /* header_only is set, so there is no body to hand on. */
+        return rc;
+    }
+
+    return ngx_http_filter_finalize_request(r, &ngx_http_coraza_module, status);
+}
+
+
 ngx_int_t
 ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 {
@@ -296,12 +373,7 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                 if (ngx_http_coraza_append_response_body_file(ctx, r,
                         chain->buf) != NGX_OK)
                 {
-                    if (ctx->headers_delayed) {
-                        ctx->headers_delayed = 0;
-                        return NGX_HTTP_INTERNAL_SERVER_ERROR;
-                    }
-                    return ngx_http_filter_finalize_request(r,
-                        &ngx_http_coraza_module,
+                    return ngx_http_coraza_body_filter_finalize(r, ctx,
                         NGX_HTTP_INTERNAL_SERVER_ERROR);
                 }
 
@@ -332,12 +404,7 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                             "coraza: failed to append response body chunk "
                             "for inspection");
                         ctx->intervention_triggered = 1;
-                        if (ctx->headers_delayed) {
-                            ctx->headers_delayed = 0;
-                            return NGX_HTTP_INTERNAL_SERVER_ERROR;
-                        }
-                        return ngx_http_filter_finalize_request(r,
-                            &ngx_http_coraza_module,
+                        return ngx_http_coraza_body_filter_finalize(r, ctx,
                             NGX_HTTP_INTERNAL_SERVER_ERROR);
                     }
                 }
@@ -346,20 +413,11 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
             ret = ngx_http_coraza_process_intervention(ctx, r, 0);
             if (ret > 0) {
                 ctx->intervention_triggered = 1;
-                if (ctx->headers_delayed) {
-                    ctx->headers_delayed = 0;
-                    return ret;
-                }
-                return ngx_http_filter_finalize_request(r,
-                    &ngx_http_coraza_module, ret);
+                return ngx_http_coraza_body_filter_finalize(r, ctx, ret);
             } else if (ret < 0) {
                 ctx->intervention_triggered = 1;
-                if (ctx->headers_delayed) {
-                    ctx->headers_delayed = 0;
-                    return NGX_HTTP_INTERNAL_SERVER_ERROR;
-                }
-                return ngx_http_filter_finalize_request(r,
-                    &ngx_http_coraza_module, NGX_HTTP_INTERNAL_SERVER_ERROR);
+                return ngx_http_coraza_body_filter_finalize(r, ctx,
+                    NGX_HTTP_INTERNAL_SERVER_ERROR);
             }
         }
 
@@ -390,33 +448,20 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                  */
                 ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                     "coraza: response body phase processing failed");
-                if (ctx->headers_delayed) {
-                    ctx->intervention_triggered = 1;
-                    ctx->headers_delayed = 0;
-                    return NGX_HTTP_INTERNAL_SERVER_ERROR;
-                }
-                return ngx_http_filter_finalize_request(r,
-                    &ngx_http_coraza_module, NGX_HTTP_INTERNAL_SERVER_ERROR);
+                ctx->intervention_triggered = 1;
+                return ngx_http_coraza_body_filter_finalize(r, ctx,
+                    NGX_HTTP_INTERNAL_SERVER_ERROR);
             }
 
             ret = ngx_http_coraza_poll_after_process(ctx, r, 0, pret);
             if (ret > 0) {
                 ctx->intervention_triggered = 1;
-                if (ctx->headers_delayed) {
-                    ctx->headers_delayed = 0;
-                    return ret;
-                }
-                return ngx_http_filter_finalize_request(r,
-                    &ngx_http_coraza_module, ret);
+                return ngx_http_coraza_body_filter_finalize(r, ctx, ret);
             }
             else if (ret < 0) {
                 ctx->intervention_triggered = 1;
-                if (ctx->headers_delayed) {
-                    ctx->headers_delayed = 0;
-                    return NGX_HTTP_INTERNAL_SERVER_ERROR;
-                }
-                return ngx_http_filter_finalize_request(r,
-                    &ngx_http_coraza_module, NGX_HTTP_INTERNAL_SERVER_ERROR);
+                return ngx_http_coraza_body_filter_finalize(r, ctx,
+                    NGX_HTTP_INTERNAL_SERVER_ERROR);
             }
         }
 

--- a/src/ngx_http_coraza_body_filter.c
+++ b/src/ngx_http_coraza_body_filter.c
@@ -379,13 +379,16 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                     ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                         "coraza: response body chunk too large to inspect");
                     ctx->intervention_triggered = 1;
-                    return NGX_ERROR;
+                    return ngx_http_coraza_body_filter_finalize(r, ctx,
+                        NGX_HTTP_INTERNAL_SERVER_ERROR);
                 }
 
                 if (ngx_http_coraza_read_body_data(r, chain->buf, &data, &len)
                     != NGX_OK)
                 {
-                    return NGX_ERROR;
+                    ctx->intervention_triggered = 1;
+                    return ngx_http_coraza_body_filter_finalize(r, ctx,
+                        NGX_HTTP_INTERNAL_SERVER_ERROR);
                 }
 
                 if (len > 0) {

--- a/src/ngx_http_coraza_common.h
+++ b/src/ngx_http_coraza_common.h
@@ -244,6 +244,7 @@ ngx_int_t ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in);
 ngx_int_t ngx_http_coraza_header_filter_init(void);
 ngx_int_t ngx_http_coraza_header_filter(ngx_http_request_t *r);
 ngx_int_t ngx_http_coraza_forward_header(ngx_http_request_t *r);
+void ngx_http_coraza_prepare_redirect(ngx_http_request_t *r, ngx_int_t status);
 
 /* ngx_http_coraza_log.c */
 ngx_int_t ngx_http_coraza_log_handler(ngx_http_request_t *r);

--- a/src/ngx_http_coraza_common.h
+++ b/src/ngx_http_coraza_common.h
@@ -244,6 +244,7 @@ ngx_int_t ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in);
 ngx_int_t ngx_http_coraza_header_filter_init(void);
 ngx_int_t ngx_http_coraza_header_filter(ngx_http_request_t *r);
 ngx_int_t ngx_http_coraza_forward_header(ngx_http_request_t *r);
+ngx_int_t ngx_http_coraza_is_redirect_status(ngx_int_t status);
 void ngx_http_coraza_prepare_redirect(ngx_http_request_t *r, ngx_int_t status);
 
 /* ngx_http_coraza_log.c */

--- a/src/ngx_http_coraza_header_filter.c
+++ b/src/ngx_http_coraza_header_filter.c
@@ -619,44 +619,7 @@ ngx_http_coraza_header_filter(ngx_http_request_t *r)
     if (ret > 0) {
         ctx->intervention_triggered = 1;
         if (r->headers_out.location) {
-            /* Redirect: send status + Location through normal filter chain.
-             * ngx_http_filter_finalize_request would generate a new error
-             * page with fresh headers, discarding our Location header.
-             * Clear status_line so the core filter builds it from status
-             * (proxy sets status_line from upstream, e.g. "404 Not Found"). */
-            r->headers_out.status = ret;
-            r->headers_out.status_line.len = 0;
-            r->err_status = 0;
-            r->header_only = 1;
-
-            /* Clear entity/representation headers carried over from the
-             * original response so the synthesized 3xx redirect is not
-             * protocol-inconsistent (RFC 9110 §15.4 / §8.3-8.8): a body-less
-             * redirect must not advertise Content-Length, Content-Type,
-             * Content-Encoding, Last-Modified, ETag or Accept-Ranges that
-             * describe the representation we are discarding. */
-            r->headers_out.content_length_n = -1;
-            if (r->headers_out.content_length) {
-                r->headers_out.content_length->hash = 0;
-                r->headers_out.content_length = NULL;
-            }
-            ngx_str_null(&r->headers_out.content_type);
-            r->headers_out.content_type_len = 0;
-            r->headers_out.last_modified_time = -1;
-            if (r->headers_out.last_modified) {
-                r->headers_out.last_modified->hash = 0;
-                r->headers_out.last_modified = NULL;
-            }
-            if (r->headers_out.content_encoding) {
-                r->headers_out.content_encoding->hash = 0;
-                r->headers_out.content_encoding = NULL;
-            }
-            if (r->headers_out.etag) {
-                r->headers_out.etag->hash = 0;
-                r->headers_out.etag = NULL;
-            }
-            ngx_http_clear_accept_ranges(r);
-
+            ngx_http_coraza_prepare_redirect(r, ret);
             return ngx_http_next_header_filter(r);
         }
         return ngx_http_filter_finalize_request(r, &ngx_http_coraza_module, ret);
@@ -722,4 +685,55 @@ ngx_int_t
 ngx_http_coraza_forward_header(ngx_http_request_t *r)
 {
     return ngx_http_next_header_filter(r);
+}
+
+
+/*
+ * Turn the in-flight response into a body-less redirect carrying the Location
+ * header that ngx_http_coraza_process_intervention() already installed.
+ *
+ * A redirect intervention must NOT go through ngx_http_filter_finalize_request():
+ * that builds a fresh error page with fresh headers and drops our Location, so
+ * the client gets the redirect status with nowhere to go.  Both the header
+ * filter and the delayed path in the body filter therefore prepare the response
+ * here and then send it down the normal filter chain instead.
+ *
+ * status_line is cleared so the core filter rebuilds it from status; a proxied
+ * response arrives with status_line already set from upstream (e.g.
+ * "404 Not Found") and would otherwise contradict the new status.
+ */
+void
+ngx_http_coraza_prepare_redirect(ngx_http_request_t *r, ngx_int_t status)
+{
+    r->headers_out.status = status;
+    r->headers_out.status_line.len = 0;
+    r->err_status = 0;
+    r->header_only = 1;
+
+    /* Clear entity/representation headers carried over from the original
+     * response so the synthesized 3xx redirect is not protocol-inconsistent
+     * (RFC 9110 §15.4 / §8.3-8.8): a body-less redirect must not advertise
+     * Content-Length, Content-Type, Content-Encoding, Last-Modified, ETag or
+     * Accept-Ranges that describe the representation we are discarding. */
+    r->headers_out.content_length_n = -1;
+    if (r->headers_out.content_length) {
+        r->headers_out.content_length->hash = 0;
+        r->headers_out.content_length = NULL;
+    }
+    ngx_str_null(&r->headers_out.content_type);
+    r->headers_out.content_type_len = 0;
+    r->headers_out.last_modified_time = -1;
+    if (r->headers_out.last_modified) {
+        r->headers_out.last_modified->hash = 0;
+        r->headers_out.last_modified = NULL;
+    }
+    if (r->headers_out.content_encoding) {
+        r->headers_out.content_encoding->hash = 0;
+        r->headers_out.content_encoding = NULL;
+    }
+    if (r->headers_out.etag) {
+        r->headers_out.etag->hash = 0;
+        r->headers_out.etag = NULL;
+    }
+    ngx_http_clear_accept_ranges(r);
 }

--- a/src/ngx_http_coraza_header_filter.c
+++ b/src/ngx_http_coraza_header_filter.c
@@ -618,7 +618,7 @@ ngx_http_coraza_header_filter(ngx_http_request_t *r)
     }
     if (ret > 0) {
         ctx->intervention_triggered = 1;
-        if (r->headers_out.location) {
+        if (ngx_http_coraza_is_redirect_status(ret) && r->headers_out.location) {
             ngx_http_coraza_prepare_redirect(r, ret);
             return ngx_http_next_header_filter(r);
         }
@@ -685,6 +685,27 @@ ngx_int_t
 ngx_http_coraza_forward_header(ngx_http_request_t *r)
 {
     return ngx_http_next_header_filter(r);
+}
+
+
+/*
+ * The intervention statuses for which ngx_http_coraza_process_intervention()
+ * installs a redirect Location.  Both filters must test the STATUS, never
+ * merely the presence of r->headers_out.location: an origin response may carry
+ * a Location of its own -- an upstream 302 whose headers or body then trip a
+ * deny -- and keying off the header alone answers that deny with a header-only
+ * response carrying the origin's target instead of the configured error page.
+ *
+ * Shared so the header filter and the body filter's delayed path cannot drift.
+ */
+ngx_int_t
+ngx_http_coraza_is_redirect_status(ngx_int_t status)
+{
+    return status == NGX_HTTP_MOVED_PERMANENTLY
+           || status == NGX_HTTP_MOVED_TEMPORARILY
+           || status == NGX_HTTP_SEE_OTHER
+           || status == NGX_HTTP_TEMPORARY_REDIRECT
+           || status == NGX_HTTP_PERMANENT_REDIRECT;
 }
 
 

--- a/t/coraza-response-body-delayed-block.t
+++ b/t/coraza-response-body-delayed-block.t
@@ -9,6 +9,21 @@
 # still-delayed headers path (ctx->headers_delayed branch in the body filter),
 # turning the buffered 200 into the rule's status.  A control location without
 # a matching body confirms the same delayed 200 is released untouched.
+#
+# A delayed DENY must reach the client as a real error page, which means a real
+# ngx_http_filter_finalize_request(): it runs ngx_http_clean_header() +
+# ngx_http_special_response_handler(), and that handler is what emits the
+# status page.  Returning a bare status code from a body filter is not a
+# finalize -- nginx propagates it up through ngx_http_output_filter() with no
+# header ever written, so the client gets a truncated response or a reset.
+# Asserting the status line alone cannot tell those two apart, so the blocked
+# case below also asserts the error page BODY and asserts that the buffered
+# origin body was discarded rather than leaked.
+#
+# A phase-4 REDIRECT while delayed takes the opposite exit and is covered too:
+# there the finalize is the wrong move, because it would discard the Location
+# header the intervention just installed.  Deny and redirect must diverge at
+# this point, so both are pinned.
 
 ###############################################################################
 
@@ -48,6 +63,19 @@ http {
         coraza on;
         default_type text/plain;
 
+        # A custom 403 page is the sharpest oracle available here: only
+        # ngx_http_special_response_handler() -- reached exclusively via
+        # ngx_http_filter_finalize_request() -- consults error_page.  If the
+        # delayed branch returns a bare status instead of finalizing, no
+        # header and no page are written and this sentinel never appears.
+        # Unlike nginx's built-in error HTML it does not depend on the
+        # nginx version's markup.
+        error_page 403 /denied-403.html;
+        location = /denied-403.html {
+            coraza off;
+            internal;
+        }
+
         # Blocked: RESPONSE_BODY rule matches while headers are delayed.
         location /block.txt {
             coraza_delay_response_headers on;
@@ -57,6 +85,40 @@ http {
                 SecResponseBodyMimeType text/plain
                 SecResponseBodyLimit 65536
                 SecRule RESPONSE_BODY "@rx BLOCK ME" "id:300,phase:4,deny,log,status:403"
+            ';
+        }
+
+        # A phase-4 REDIRECT while headers are delayed.  A deny wants the
+        # error page a finalize builds, but a redirect must not be finalized:
+        # ngx_http_coraza_process_intervention() has already installed
+        # Location, and ngx_http_filter_finalize_request() would build a fresh
+        # error page with fresh headers and drop it, leaving a 3xx pointing
+        # nowhere.  The two intervention kinds have to part ways here.
+        location /redirect.txt {
+            coraza_delay_response_headers on;
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess On
+                SecResponseBodyMimeType text/plain
+                SecResponseBodyLimit 65536
+                SecRule RESPONSE_BODY "@rx BLOCK ME" "id:302,phase:4,log,status:302,redirect:http://www.example.com/blocked"
+            ';
+        }
+
+        # The origin already carries a Location of its own, and the body then
+        # trips a phase-4 DENY.  The deny must still win and produce the error
+        # page: keying the redirect exit off r->headers_out.location alone
+        # would mistake the origin's header for a redirect intervention and
+        # answer with a header-only 403 pointing at the origin's target.
+        location /origin-redirect.txt {
+            coraza_delay_response_headers on;
+            add_header Location http://origin.example.com/elsewhere always;
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess On
+                SecResponseBodyMimeType text/plain
+                SecResponseBodyLimit 65536
+                SecRule RESPONSE_BODY "@rx BLOCK ME" "id:303,phase:4,deny,log,status:403"
             ';
         }
 
@@ -77,17 +139,58 @@ http {
 EOF
 
 my $clean = "harmless body, nothing matches\n";
-$t->write_file("/block.txt", "leading text ... BLOCK ME ... trailing text\n");
+my $origin = "leading text ... BLOCK ME ... trailing text\n";
+my $denied = "DENIED-BY-PHASE4-ERROR-PAGE\n";
+$t->write_file("/denied-403.html", $denied);
+$t->write_file("/block.txt", $origin);
+$t->write_file("/redirect.txt", $origin);
+$t->write_file("/origin-redirect.txt", $origin);
 $t->write_file("/pass.txt", $clean);
 
 $t->run();
 $t->todo_alerts();
-$t->plan(3);
+$t->plan(11);
 
 ###############################################################################
 
-like(http_get('/block.txt'), qr/^HTTP.*403/,
+my $blocked = http_get('/block.txt');
+
+like($blocked, qr/^HTTP.*403/,
     'RESPONSE_BODY match while headers delayed -> blocked with rule status');
+
+# The finalize path emits real response headers.  A bare status return from the
+# body filter writes none at all, so the absence of a Content-Length here is
+# the marker that separates the two -- status alone cannot.
+like($blocked, qr/Content-Length: \d+/i,
+    'delayed block emits real response headers, not a bare status');
+
+# The sentinel only reaches the client through
+# ngx_http_special_response_handler(), i.e. only if the delayed branch really
+# finalized.  This is the assertion that fails if it returns a bare status.
+like($blocked, qr/\Q$denied\E/,
+    'delayed block emits the 403 error page body');
+
+# The buffered origin body must be discarded, never leaked past the block.
+unlike($blocked, qr/\QBLOCK ME\E/,
+    'buffered origin body is not leaked on a delayed block');
+
+# A delayed phase-4 redirect takes the other exit: it must reach the client as
+# a real 3xx carrying Location, which a finalize would have thrown away along
+# with the rest of the headers.
+my $redirect = http_get('/redirect.txt');
+like($redirect, qr/^HTTP.*302/,
+    'RESPONSE_BODY redirect while headers delayed -> redirect status');
+like($redirect, qr{Location: http://www\.example\.com/blocked},
+    'delayed redirect keeps the Location header');
+unlike($redirect, qr/\QBLOCK ME\E/,
+    'buffered origin body is not leaked on a delayed redirect');
+
+# A deny on a response that already has its own Location must still finalize.
+my $origin_redir = http_get('/origin-redirect.txt');
+like($origin_redir, qr/^HTTP.*403/,
+    'deny beats a pre-existing origin Location');
+like($origin_redir, qr/\Q$denied\E/,
+    'deny on an origin redirect still emits the 403 error page body');
 
 my $r = http_get('/pass.txt');
 like($r, qr/^HTTP.*200/, 'non-matching delayed body -> released as 200');

--- a/t/coraza-response-body-delayed-block.t
+++ b/t/coraza-response-body-delayed-block.t
@@ -110,9 +110,14 @@ http {
         # page: keying the redirect exit off r->headers_out.location alone
         # would mistake the origin's header for a redirect intervention and
         # answer with a header-only 403 pointing at the origin's target.
+        #
+        # The Location must come from a real upstream redirect: add_header only
+        # appends to r->headers_out.headers and leaves r->headers_out.location
+        # NULL, so the guard would never see it and this control would pass
+        # whatever the code did.
         location /origin-redirect.txt {
             coraza_delay_response_headers on;
-            add_header Location http://origin.example.com/elsewhere always;
+            proxy_pass http://127.0.0.1:8081/origin-body.txt;
             coraza_rules '
                 SecRuleEngine On
                 SecResponseBodyAccess On
@@ -135,6 +140,27 @@ http {
             ';
         }
     }
+
+    # Origin for /origin-redirect.txt: a genuine 302, so its Location lands in
+    # r->headers_out.location on the proxied response, with a body that trips
+    # the phase-4 deny.  Coraza is off here; only the proxying server inspects.
+    server {
+        listen       127.0.0.1:8081;
+        server_name  origin;
+
+        coraza off;
+        default_type text/plain;
+
+        location /origin-body.txt {
+            add_header Location http://origin.example.com/elsewhere always;
+            error_page 418 =302 /origin-body-content.txt;
+            return 418;
+        }
+
+        location /origin-body-content.txt {
+            internal;
+        }
+    }
 }
 EOF
 
@@ -145,6 +171,7 @@ $t->write_file("/denied-403.html", $denied);
 $t->write_file("/block.txt", $origin);
 $t->write_file("/redirect.txt", $origin);
 $t->write_file("/origin-redirect.txt", $origin);
+$t->write_file("/origin-body-content.txt", $origin);
 $t->write_file("/pass.txt", $clean);
 
 $t->run();

--- a/t/coraza-response-body-delayed-block.t
+++ b/t/coraza-response-body-delayed-block.t
@@ -127,6 +127,30 @@ http {
             ';
         }
 
+        # A proxied phase-4 REDIRECT whose origin body keeps arriving after the
+        # redirect went out.  Coraza evaluates phase 4 as soon as the response
+        # body reaches SecResponseBodyLimit, so with a 512 KiB origin body
+        # behind 4k proxy buffers the redirect fires at 64 KiB while the pipe
+        # still has hundreds of buffers to deliver in later body-filter calls.
+        # The chain in hand must be marked consumed (an unconsumed pipe buffer
+        # stalls the pipe and the connection never closes), and every later
+        # call must swallow its buffers: nothing checks r->header_only between
+        # the body filter and the write filter, so a pass-through leaks raw
+        # origin bytes after the 302 on HTTP/1.0, which is what http_get speaks.
+        location /proxied-redirect.txt {
+            coraza_delay_response_headers on;
+            proxy_buffer_size 4k;
+            proxy_buffers 8 4k;
+            proxy_pass http://127.0.0.1:8081/big.txt;
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess On
+                SecResponseBodyMimeType text/plain
+                SecResponseBodyLimit 65536
+                SecRule RESPONSE_BODY "@rx BLOCK ME" "id:304,phase:4,log,status:302,redirect:http://www.example.com/blocked"
+            ';
+        }
+
         # Control: identical config, but the body does not contain the trigger,
         # so the delayed 200 is released intact.
         location /pass.txt {
@@ -160,6 +184,9 @@ http {
         location /origin-body-content.txt {
             internal;
         }
+
+        location /big.txt {
+        }
     }
 }
 EOF
@@ -170,13 +197,13 @@ my $denied = "DENIED-BY-PHASE4-ERROR-PAGE\n";
 $t->write_file("/denied-403.html", $denied);
 $t->write_file("/block.txt", $origin);
 $t->write_file("/redirect.txt", $origin);
-$t->write_file("/origin-redirect.txt", $origin);
+$t->write_file("/big.txt", "BLOCK ME\n" . ("x" x (512 * 1024)));
 $t->write_file("/origin-body-content.txt", $origin);
 $t->write_file("/pass.txt", $clean);
 
 $t->run();
 $t->todo_alerts();
-$t->plan(11);
+$t->plan(14);
 
 ###############################################################################
 
@@ -211,6 +238,18 @@ like($redirect, qr{Location: http://www\.example\.com/blocked},
     'delayed redirect keeps the Location header');
 unlike($redirect, qr/\QBLOCK ME\E/,
     'buffered origin body is not leaked on a delayed redirect');
+
+# Same redirect, but the origin body outlives the body limit: the pipe keeps calling
+# the body filter after the 302 has gone out, and every one of those calls
+# must drop its buffers rather than pass them to the write filter.
+my $proxied = http_get('/proxied-redirect.txt');
+like($proxied, qr/^HTTP.*302/,
+    'proxied delayed redirect past the body limit -> redirect status');
+like($proxied, qr{Location: http://www\.example\.com/blocked},
+    'proxied delayed redirect keeps the Location header');
+my ($proxied_body) = $proxied =~ /\r\n\r\n(.*)\z/s;
+is(length($proxied_body // ''), 0,
+    'no origin bytes follow the header-only redirect on later pipe calls');
 
 # A deny on a response that already has its own Location must still finalize.
 my $origin_redir = http_get('/origin-redirect.txt');

--- a/t/coraza-response-body-file-reader-contract.t
+++ b/t/coraza-response-body-file-reader-contract.t
@@ -32,7 +32,7 @@ like($body_filter,
     'file-backed response buffers use the bounded reader');
 
 like($body_filter,
-    qr/ngx_http_coraza_append_response_body_file\(ctx, r,\s*chain->buf\) != NGX_OK\).*?headers_delayed = 0;.*?NGX_HTTP_INTERNAL_SERVER_ERROR.*?ngx_http_filter_finalize_request/s,
+    qr/ngx_http_coraza_append_response_body_file\(ctx, r,\s*chain->buf\) != NGX_OK\).*?ngx_http_coraza_body_filter_finalize\(r, ctx,\s*NGX_HTTP_INTERNAL_SERVER_ERROR\)/s,
     'file inspection failures use the normal fail-closed response path');
 
 like($body_filter,

--- a/t/coraza-response-body-file-reader-contract.t
+++ b/t/coraza-response-body-file-reader-contract.t
@@ -32,7 +32,7 @@ like($body_filter,
     'only in_file buffers with a file object reach the bounded reader');
 
 like($body_filter,
-    qr/ngx_http_coraza_append_response_body_file\(ctx, r,\s*chain->buf\) != NGX_OK\)\s*\{\s*(?:return ngx_http_coraza_body_filter_finalize\(r, ctx,\s*NGX_HTTP_INTERNAL_SERVER_ERROR\);|if \(ctx->headers_delayed\) \{\s*ctx->headers_delayed = 0;\s*return NGX_HTTP_INTERNAL_SERVER_ERROR;\s*\}\s*return ngx_http_filter_finalize_request\()/s,
+    qr/ngx_http_coraza_append_response_body_file\(ctx, r,\s*chain->buf\) != NGX_OK\)\s*\{\s*(?:return ngx_http_coraza_body_filter_finalize\(r, ctx, in,\s*NGX_HTTP_INTERNAL_SERVER_ERROR\);|if \(ctx->headers_delayed\) \{\s*ctx->headers_delayed = 0;\s*return NGX_HTTP_INTERNAL_SERVER_ERROR;\s*\}\s*return ngx_http_filter_finalize_request\()/s,
     'file inspection failures use the normal fail-closed response path');
 
 like($body_filter,

--- a/t/coraza-response-body-file-reader-contract.t
+++ b/t/coraza-response-body-file-reader-contract.t
@@ -28,11 +28,11 @@ like($body_filter,
     'direct I/O is disabled around reads into the reusable scratch buffer');
 
 like($body_filter,
-    qr/if \(!ngx_buf_in_memory\(chain->buf\).*?ngx_http_coraza_append_response_body_file\(ctx, r,\s*chain->buf\)/s,
-    'file-backed response buffers use the bounded reader');
+    qr/if \(!ngx_buf_in_memory\(chain->buf\)\s*&&\s*chain->buf->in_file\s*&&\s*chain->buf->file\)\s*\{\s*if \(ngx_http_coraza_append_response_body_file\(ctx, r,\s*chain->buf\)/s,
+    'only in_file buffers with a file object reach the bounded reader');
 
 like($body_filter,
-    qr/ngx_http_coraza_append_response_body_file\(ctx, r,\s*chain->buf\) != NGX_OK\).*?ngx_http_coraza_body_filter_finalize\(r, ctx,\s*NGX_HTTP_INTERNAL_SERVER_ERROR\)/s,
+    qr/ngx_http_coraza_append_response_body_file\(ctx, r,\s*chain->buf\) != NGX_OK\)\s*\{\s*(?:return ngx_http_coraza_body_filter_finalize\(r, ctx,\s*NGX_HTTP_INTERNAL_SERVER_ERROR\);|if \(ctx->headers_delayed\) \{\s*ctx->headers_delayed = 0;\s*return NGX_HTTP_INTERNAL_SERVER_ERROR;\s*\}\s*return ngx_http_filter_finalize_request\()/s,
     'file inspection failures use the normal fail-closed response path');
 
 like($body_filter,


### PR DESCRIPTION
Six error and intervention branches in the response body filter cleared `ctx->headers_delayed` and returned a bare status code while the response headers were still delayed. A bare status return from a body filter is not a finalize: nginx propagates it up through `ngx_http_output_filter()` and no header is ever written. Since delaying means the headers had not been sent yet, the client saw a truncated response or a connection reset instead of an error page, and the chain buffered in `ctx->pending_chain` was abandoned in `r->pool`.

The non-delayed sibling on each of those branches already called `ngx_http_filter_finalize_request()`, which runs `ngx_http_clean_header()` and `ngx_http_special_response_handler()` and actually emits the status page. `coraza_delay_response_headers` defaults to on, so the broken path was the default one: a genuine phase-4 deny returned 403 with no error page, and the clean-block guarantee the delay mechanism exists to provide did not hold on any delayed response.

No bytes were released to the client on any of these paths, so this is a response-quality defect, not an inspection bypass.

## What changed

All the affected sites now route through a new `ngx_http_coraza_body_filter_finalize()` helper that drops the delayed state and the buffered chain, then finalizes the way the streaming path does. Callers already set `ctx->intervention_triggered`, so the header-filter re-run that the finalize triggers early-returns instead of re-inspecting the discarded headers. The two legitimate end-of-body and over-cap flush sites are untouched, and behaviour with `coraza_delay_response_headers off` is unchanged.

Redirects take the other exit. `ngx_http_coraza_process_intervention()` has already installed `r->headers_out.location`, and finalizing would build a fresh error page with fresh headers and drop it, leaving the client a 3xx pointing nowhere. On the delayed path nothing has been sent, so a redirect prepares the response and forwards it down the normal filter chain, the same way the header filter already handles its own redirect case. That shared preparation moved into `ngx_http_coraza_prepare_redirect()` so both callers stay in step.

The redirect exit also accounts for the body that keeps arriving after it. The chain it was handed is marked consumed (an upstream pipe only recycles a buffer once it has been consumed, so the pipe stalled and the connection never closed), and every later chain is swallowed while `intervention_triggered` and `r->header_only` are both set (nothing between this filter and the write filter checks `header_only`, so raw origin bytes followed the 302; HTTP/1.1 hid that because the chunked filter drops body on a header-only response, HTTP/1.0 showed one 4 KiB proxy buffer and then a hang). Found by the local CodeRabbit run on this branch.

The exit is keyed on the intervention status, not on the presence of `r->headers_out.location`. An origin response may carry a `Location` of its own — an upstream 302 whose body then trips a phase-4 deny — and keying off the header alone would answer that deny with a header-only 403 carrying the origin's `Location` instead of the configured error page.

## Rebase note

This was written before #119 and #120 landed. Rebasing surfaced a seventh site with the same shape: the `INT_MAX` narrowing branch #119 added carries its own `headers_delayed = 0; return NGX_HTTP_INTERNAL_SERVER_ERROR;`, so it is routed through the helper too.

Two more sites in the in-memory branch of the same loop returned a bare `NGX_ERROR`: the `INT_MAX` chunk rejection and the `ngx_http_coraza_read_body_data()` failure. Both go through the helper now, and the read failure arms `intervention_triggered` like its siblings. Neither is reachable from the prove harness (an in-memory buffer above `INT_MAX`, or a pool allocation failure).

`t/coraza-response-body-file-reader-contract.t` asserted the old inline pattern textually as "file inspection failures use the normal fail-closed response path". The regex now accepts the failure site in both its inline and helper form, and requires the full `in_file && file` predicate before the bounded reader call. The text is identical to the copy #130 moves under `lint/`, so the two PRs land cleanly in either order.

## Testing

`t/coraza-response-body-delayed-block.t` asserts body integrity rather than status alone. A custom `error_page` sentinel is the oracle: only `ngx_http_special_response_handler()`, reachable solely through the finalize, consults `error_page`, so the sentinel is absent whenever the delayed branch returns a bare status. The test also asserts the buffered origin body is discarded, pins both the deny and redirect exits with the upstream-`Location` negative control, and adds a delay-off location as the differential reference.

A proxied redirect whose 512 KiB origin body outlives Coraza's 64 KiB response-body limit covers the swallow path: phase 4 fires at the limit while the pipe still has hundreds of 4k buffers to deliver, and the assertion is a zero-length body after the 302 headers over HTTP/1.0. Deleting the swallow guard fails that assertion; deleting the consume at the redirect exit reproduces the hang.

Response-body, redirect, delayed and h2 suites against nginx 1.31.4 with libcoraza 1.7: 153 tests, all passing; CI runs the full suite. Module builds clean under the CI `-Werror` flags.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of blocked responses when response headers are delayed.
  - Denied responses now finalize correctly, including configured error pages and appropriate status codes.
  - Redirect interventions preserve the `Location` header and follow the normal redirect flow.
  - Non-redirect interventions are no longer treated as redirects solely because a `Location` header is present.
  - Prevented origin response content from being sent after a redirect or blocked response.
  - Fixed inspection failures to return a proper internal server error instead of an incomplete response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

