### PR TITLE
fix: guard body filter error pages and header filter loc conf

### DIFF
--- a/src/ngx_http_coraza_body_filter.c
+++ b/src/ngx_http_coraza_body_filter.c
@@ -344,6 +344,16 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
             }
 
             ret = ngx_http_coraza_process_intervention(ctx, r, 0);
+            /*
+             * Mirror the r->error_page guard the other three poll sites
+             * (rewrite, pre_access, header_filter) apply right after their
+             * own poll: once nginx is already streaming the configured
+             * error page's body, a fresh deny here must not finalize the
+             * request a second time.
+             */
+            if (r->error_page) {
+                return ngx_http_next_body_filter(r, in);
+            }
             if (ret > 0) {
                 ctx->intervention_triggered = 1;
                 if (ctx->headers_delayed) {
@@ -400,6 +410,14 @@ ngx_http_coraza_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
             }
 
             ret = ngx_http_coraza_poll_after_process(ctx, r, 0, pret);
+            /*
+             * Same r->error_page guard as above and as the other three poll
+             * sites: a phase-4 intervention while nginx is already streaming
+             * the configured error page's body must not finalize again.
+             */
+            if (r->error_page) {
+                return ngx_http_next_body_filter(r, in);
+            }
             if (ret > 0) {
                 ctx->intervention_triggered = 1;
                 if (ctx->headers_delayed) {

--- a/src/ngx_http_coraza_header_filter.c
+++ b/src/ngx_http_coraza_header_filter.c
@@ -430,12 +430,26 @@ ngx_http_coraza_header_filter(ngx_http_request_t *r)
     }
 
     mcf = ngx_http_get_module_loc_conf(r, ngx_http_coraza_module);
+    if (mcf == NULL) {
+        return ngx_http_next_header_filter(r);
+    }
 
     if (ctx->intervention_triggered) {
         return ngx_http_next_header_filter(r);
     }
 
-    /* Skip if already processed (can happen with subrequests or error pages) */
+    /*
+     * ctx->processed is deliberately sticky for the lifetime of this ctx: it
+     * guards against this filter running twice for the same ctx, not against
+     * running once per "logical" response. An internal redirect
+     * (error_page, X-Accel-Redirect) reuses the same r/ctx across the hop,
+     * but nginx invokes the header filter chain only once, for the final
+     * response actually sent to the client -- redirected phases never reach
+     * this filter, so there is nothing here for the flag to wrongly
+     * suppress. A subrequest gets its own r and, unless it creates one, a
+     * NULL ctx (see ngx_http_coraza_create_ctx() callers), so it is
+     * unaffected by the parent's flag. Do not reset this flag.
+     */
     if (ctx && ctx->processed)
     {
         return ngx_http_next_header_filter(r);

--- a/src/ngx_http_coraza_module.c
+++ b/src/ngx_http_coraza_module.c
@@ -745,7 +745,15 @@ ngx_http_coraza_init_process(ngx_cycle_t *cycle)
 	ngx_http_coraza_conf_t **loc_confs;
 	ngx_uint_t i;
 
-	/* Step 1: load libcoraza.so — Go runtime initializes fresh here */
+	/*
+	 * Step 1: load libcoraza.so.  This must happen after fork, in each
+	 * worker, never in the master: a Go runtime already running when
+	 * nginx forks would have its threads silently dropped in the child,
+	 * so no Go code may ever run in the master process.  dlopen()-ing
+	 * here instead lets the Go runtime inside libcoraza start fresh in
+	 * every worker, avoiding the post-fork deadlock (see
+	 * ngx_http_coraza_dl.c).
+	 */
 	if (ngx_http_coraza_dl_open(cycle->log) != NGX_OK) {
 		return NGX_ERROR;
 	}

--- a/t/coraza-body-filter-error-page-guard.t
+++ b/t/coraza-body-filter-error-page-guard.t
@@ -1,0 +1,99 @@
+#!/usr/bin/perl
+
+# Tests for Coraza-nginx connector: the response body filter must not act on
+# a fresh phase-4 intervention while nginx is already streaming the
+# configured error_page's own body (r->error_page set).
+#
+# A phase-1 denial is routed through error_page into a second coraza-on
+# location whose response BODY would trip a phase-4 RESPONSE_BODY rule if the
+# connector re-inspected the error page's own content.  The body filter now
+# carries the same r->error_page guard the rewrite, pre_access and
+# header_filter poll sites already had (see
+# ngx_http_coraza_body_filter.c: both poll_after_process consumers).  Without
+# that guard the phase-4 rule below would fire on the error page's own body
+# and finalize the request a second time, rewriting the status the client
+# sees and risking a double-finalize on an already-erroring request.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http/);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+        default_type text/plain;
+
+        coraza on;
+
+        # A phase-1 denial whose 403 is routed into the coraza-on /denied
+        # handler, forcing an internal error-page re-entry that streams a
+        # response body through the body filter with r->error_page set.
+        location /trigger {
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess On
+                SecRule ARGS:x "@streq boom" "id:600,phase:1,deny,log,status:403"
+            ';
+            error_page 403 = /denied;
+            return 200 "should not reach";
+        }
+
+        # The error-page target is coraza-on with response-body access, and
+        # its own body contains "forbidden" -- a string that WOULD trip the
+        # phase-4 rule below (status 418) if the body filter re-inspected the
+        # error page's own content instead of honoring r->error_page.
+        location /denied {
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess On
+                SecRule RESPONSE_BODY "@contains forbidden" "id:601,phase:4,deny,log,status:418"
+            ';
+            return 403 "forbidden by coraza\n";
+        }
+    }
+}
+EOF
+
+$t->run();
+$t->todo_alerts();
+$t->plan(3);
+
+###############################################################################
+
+# The denial is routed through the coraza-on error page; the phase-4 rule on
+# the error page's own body must not re-fire and rewrite the status to 418.
+my $r = http_get('/trigger?x=boom');
+like($r, qr/^HTTP\S+ 403/,
+    'error-page body filter did not re-finalize (still 403, not 418)');
+like($r, qr/forbidden by coraza/, 'error_page handler body delivered intact');
+
+# Control: a clean request never routes through the error page at all.
+like(http_get('/trigger?x=safe'), qr/^HTTP\S+ 200/,
+    'clean request passes without error-page re-entry (control)');

--- a/t/coraza-body-filter-error-page-guard.t
+++ b/t/coraza-body-filter-error-page-guard.t
@@ -59,7 +59,7 @@ http {
             coraza_rules '
                 SecRuleEngine On
                 SecResponseBodyAccess On
-                SecRule ARGS:x "@streq boom" "id:600,phase:1,deny,log,status:403"
+                SecRule ARGS:x "@streq boom" "id:600,phase:1,deny,log,status:403,t:none"
             ';
             error_page 403 = /denied;
             return 200 "should not reach";
@@ -73,9 +73,23 @@ http {
             coraza_rules '
                 SecRuleEngine On
                 SecResponseBodyAccess On
-                SecRule RESPONSE_BODY "@contains forbidden" "id:601,phase:4,deny,log,status:418"
+                SecResponseBodyMimeType text/plain
+                SecRule RESPONSE_BODY "@contains forbidden" "id:601,phase:4,deny,log,status:418,t:none"
             ';
             return 403 "forbidden by coraza\n";
+        }
+
+        # Positive phase-4 control without nginx's special-response path.
+        # Returning 403 directly also sets r->error_page, so /denied itself
+        # cannot distinguish a working phase-4 engine from the guard above.
+        location /phase4-control {
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess On
+                SecResponseBodyMimeType text/plain
+                SecRule RESPONSE_BODY "@contains forbidden" "id:602,phase:4,deny,log,status:418,t:none"
+            ';
+            return 200 "forbidden control body\n";
         }
     }
 }
@@ -83,7 +97,7 @@ EOF
 
 $t->run();
 $t->todo_alerts();
-$t->plan(3);
+$t->plan(4);
 
 ###############################################################################
 
@@ -93,6 +107,12 @@ my $r = http_get('/trigger?x=boom');
 like($r, qr/^HTTP\S+ 403/,
     'error-page body filter did not re-finalize (still 403, not 418)');
 like($r, qr/forbidden by coraza/, 'error_page handler body delivered intact');
+
+# An ordinary 200 response must still run phase 4.  This is the positive
+# control for the error-page guard above: an over-broad guard that disabled
+# response-body inspection would otherwise satisfy both assertions.
+like(http_get('/phase4-control'), qr/^HTTP\S+ 418/,
+    'phase-4 rule blocks an ordinary response outside error_page');
 
 # Control: a clean request never routes through the error page at all.
 like(http_get('/trigger?x=safe'), qr/^HTTP\S+ 200/,


### PR DESCRIPTION
Two independent fixes to the body filter's error-page handling, plus a set of header-filter and module hygiene corrections that were sitting in the same area.

## Body filter intervention polls ignored `r->error_page`

The response body filter's two intervention polls — the per-buffer `process_intervention()` call and the last-buffer phase-4 poll — were the only two of the four `coraza_poll_after_process()` call sites with no `r->error_page` check. `rewrite.c`, `pre_access.c` and `header_filter.c` all bail out right after polling once nginx is already streaming the configured error page, so a fresh deny raised while serving that page cannot finalize the request a second time.

This gap was reachable rather than theoretical: `ctx->response_body_processable` is set by the header filter regardless of `r->error_page`, so phase-4 rules do run against an error page's own body. Both poll sites now carry the same guard as the other three phases.

`t/coraza-body-filter-error-page-guard.t` routes a phase-1 denial through a `coraza on` `error_page` location whose own response body would trip a phase-4 rule if the body filter re-inspected it instead of honouring `r->error_page`.

## Header filter and module hygiene

- `ctx->processed` is deliberately sticky for the life of a `ctx` — a one-shot guard against the filter running twice for the same request, not a per-hop flag. Documented so a future reader does not "fix" it by resetting it on internal redirects, where nginx never re-enters this filter anyway.
- The header filter's loc-conf lookup is now NULL-checked before use, matching the shape already used by the log, rewrite and pre-access handlers.
- Corrected the `init_process` comment. libcoraza is dlopen'd after fork, in each worker, because no Go code may ever run in the master process — a Go runtime's threads are dropped across `fork()`. It is not a startup-ordering detail. This now agrees with the rationale already written in `ngx_http_coraza_dl.c`.

## Testing

Full suite against nginx 1.31.4 with libcoraza 1.7: 417 tests, all passing. Module builds clean under the CI `-Werror` flags.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed response handling during internal error-page redirects to prevent error pages from being processed more than once.
  - Preserved the correct error status and ensured the response body is delivered as expected.
  - Improved handling when request configuration is unavailable, allowing processing to continue safely.

- **Documentation**
  - Clarified runtime initialization behavior and internal redirect processing for improved maintainability.

- **Tests**
  - Added coverage for error-page redirects, response-body delivery, status preservation, and successful requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->