### PR TITLE
fix: intervention poll consistency in the pre-access handler

### DIFF
--- a/src/ngx_http_coraza_log.c
+++ b/src/ngx_http_coraza_log.c
@@ -27,7 +27,8 @@ ngx_http_coraza_log_handler(ngx_http_request_t *r)
     ctx = ngx_http_get_module_ctx(r, ngx_http_coraza_module);
 
     if (ctx == NULL) {
-        return NGX_ERROR;
+        /* LOG-phase handlers must return NGX_OK */
+        return NGX_OK;
     }
 
     if (ctx->logged) {

--- a/src/ngx_http_coraza_module.c
+++ b/src/ngx_http_coraza_module.c
@@ -369,13 +369,13 @@ static ngx_command_t ngx_http_coraza_commands[] = {
 	 NGX_HTTP_LOC_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1,
 	 ngx_conf_set_rules,
 	 NGX_HTTP_LOC_CONF_OFFSET,
-	 offsetof(ngx_http_coraza_conf_t, enable),
+	 0,
 	 NULL},
 	{ngx_string("coraza_rules_file"),
 	 NGX_HTTP_LOC_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1,
 	 ngx_conf_set_rules_file,
 	 NGX_HTTP_LOC_CONF_OFFSET,
-	 offsetof(ngx_http_coraza_conf_t, enable),
+	 0,
 	 NULL},
 	{ngx_string("coraza_transaction_id"),
 	 NGX_HTTP_LOC_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1,
@@ -783,13 +783,6 @@ ngx_http_coraza_init_process(ngx_cycle_t *cycle)
 		ngx_http_coraza_conf_t *lcf = loc_confs[i];
 
 		if (!lcf->has_rules || lcf->rules->nelts == 0) {
-			continue;
-		}
-
-		/* If this loc_conf shares a rules pointer with main or another
-		 * loc_conf that we already built, reuse that WAF. */
-		if (lcf->rules == mmcf->rules && mmcf->waf != 0) {
-			lcf->waf = mmcf->waf;
 			continue;
 		}
 

--- a/src/ngx_http_coraza_pre_access.c
+++ b/src/ngx_http_coraza_pre_access.c
@@ -177,6 +177,19 @@ ngx_http_coraza_append_request_body_file(ngx_http_coraza_ctx_t *ctx,
 
         if (offset < body_size) {
             ret = ngx_http_coraza_process_intervention(ctx, r, 0);
+            /*
+             * On an error_page re-entry pass a prior intervention has
+             * already been finalized, so yield instead of finalizing
+             * again -- the same treatment as the final poll below and as
+             * the two body-filter poll sites.  Yield explicitly rather
+             * than falling through to the cleanup with rc still NGX_OK,
+             * which would report the whole body inspected while the
+             * remaining chunks were never appended.
+             */
+            if (r->error_page) {
+                rc = NGX_DECLINED;
+                goto done;
+            }
             if (ret < 0) {
                 rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
                 goto done;
@@ -196,7 +209,12 @@ done:
             ngx_close_file_n " \"%V\" failed", &file.name);
     }
 
-    if (rc != NGX_OK) {
+    /*
+     * NGX_DECLINED is the deliberate error_page-re-entry yield above, not a
+     * failure: the sibling poll sites yield without arming the flag, so this
+     * one must not arm it either.
+     */
+    if (rc != NGX_OK && rc != NGX_DECLINED) {
         ctx->intervention_triggered = 1;
     }
 
@@ -368,6 +386,13 @@ ngx_http_coraza_pre_access_handler(ngx_http_request_t *r)
 
             /* Check for intervention after each chunk for prompt detection */
             ret = ngx_http_coraza_process_intervention(ctx, r, 0);
+            /*
+             * If nginx has already started streaming the error page body
+             * after a prior intervention, do not attempt another finalize.
+             */
+            if (r->error_page) {
+                return NGX_DECLINED;
+            }
             if (ret < 0) {
                 /* NGX_ERROR from the intervention handler: fail closed. */
                 ctx->intervention_triggered = 1;

--- a/t/coraza-request-body-error-page-reentry.t
+++ b/t/coraza-request-body-error-page-reentry.t
@@ -12,12 +12,27 @@
 # already serving.  Phase-2 processing never runs on that pass, so a body
 # rule in the error_page location must not turn the 404 into a 403.
 #
-# The large body is bigger than client_body_buffer_size (temp file) and
-# bigger than the 64 KiB file chunk, so the file loop takes more than one
-# iteration and its in-loop poll site is actually exercised.
+# Three body shapes reach three different poll sites.  The small body fits
+# in the header preread, so its single buffer is last_buf and the in-memory
+# loop breaks before its poll.  The medium body is larger than what remains
+# of the preread buffer but smaller than client_body_buffer_size, so nginx
+# reads the rest into a second in-memory buffer and the in-memory in-loop
+# poll runs on the first one.  The large body is bigger than
+# client_body_buffer_size (temp file) and bigger than the 64 KiB file chunk,
+# so the file loop takes more than one iteration and its in-loop poll site
+# is actually exercised.  $request_body_file in the access log pins the
+# memory-versus-file split: "-" for the medium body, a path for the large one.
 #
-# The direct POST controls prove the body rule and both body paths work when
-# no error_page is involved, so the 404 outcomes above are not vacuous.
+# The direct POST controls prove the body rule and all three body paths work
+# when no error_page is involved, so the 404 outcomes above are not vacuous.
+#
+# Limit: the in-loop yields are reached but not status-observable here.
+# Phase-2 rules only run in the final process-request-body step, so the
+# in-loop polls return 0 on the re-entry pass whatever the guard does, and a
+# deny on the first pass returns from the handler before the loop.  Deleting
+# the in-memory in-loop error_page yield leaves this file green; the final
+# poll's yield is what the 404 assertions pin, and the in-loop cases prove
+# the sites are executed without a crash on that pass.
 
 ###############################################################################
 
@@ -51,9 +66,13 @@ events {
 http {
     %%TEST_GLOBALS_HTTP%%
 
+    log_format body '$request_uri body_file=[$request_body_file]';
+
     server {
         listen       127.0.0.1:8080;
         server_name  localhost;
+
+        access_log %%TESTDIR%%/body.log body;
 
         coraza on;
         client_body_buffer_size 8k;
@@ -123,7 +142,7 @@ EOF
 
 $t->run();
 $t->todo_alerts();
-$t->plan(9);
+$t->plan(14);
 
 ###############################################################################
 
@@ -139,11 +158,14 @@ sub post {
 }
 
 my $small = "a=leading+TRIGGER-BODY+trailing";
+my $medium = "a=" . ("x" x 2048) . "TRIGGER-BODY" . ("y" x 2048);  # ~4 KiB
 my $large = "a=" . ("x" x 65536) . "TRIGGER-BODY" . ("y" x 131072);  # ~192 KiB
 
 # Controls first: the rule and both body paths work without error_page.
 like(post('/direct', $small), qr/^HTTP\S+ 403/,
     'control: in-memory body trips the phase-2 rule on a direct request');
+like(post('/direct', $medium), qr/^HTTP\S+ 403/,
+    'control: two-buffer in-memory body trips the phase-2 rule');
 like(post('/direct', $large), qr/^HTTP\S+ 403/,
     'control: file-buffered multi-chunk body trips the phase-2 rule');
 like(post('/direct', "a=harmless"), qr/^HTTP\S+ 200/,
@@ -156,8 +178,16 @@ like($r, qr/^HTTP\S+ 404/,
 like($r, qr/fallback page/,
     'in-memory body: error_page location body delivered on re-entry');
 
+# error_page re-entry, in-memory body spanning two buffers so the in-memory
+# in-loop poll runs on the re-entry pass.
+$r = post('/missing?medium', $medium);
+like($r, qr/^HTTP\S+ 404/,
+    'two-buffer body: error_page re-entry keeps the 404 across the in-loop poll');
+like($r, qr/fallback page/,
+    'two-buffer body: error_page location body delivered on re-entry');
+
 # error_page re-entry, file-buffered body spanning more than one chunk.
-$r = post('/missing', $large);
+$r = post('/missing?large', $large);
 like($r, qr/^HTTP\S+ 404/,
     'file body: error_page re-entry keeps the 404 across in-loop polls');
 like($r, qr/fallback page/,
@@ -165,6 +195,14 @@ like($r, qr/fallback page/,
 
 # Worker survived all of it.
 like(http_get('/direct'), qr/^HTTP\S+ 200/, 'worker still serving afterwards');
+
+# The medium body must have stayed in memory and the large one must have
+# spilled, or the two re-entry cases above exercised the same poll site.
+my $body_log = $t->read_file('body.log');
+like($body_log, qr{^/missing\?medium body_file=\[-\]$}m,
+    'medium body was read into memory, not a temp file');
+like($body_log, qr{^/missing\?large body_file=\[/\S+\]$}m,
+    'large body was buffered to a temp file');
 
 my $log = $t->read_file('error.log');
 unlike($log, qr/signal 11|SIGSEGV|AddressSanitizer/,

--- a/t/coraza-request-body-error-page-reentry.t
+++ b/t/coraza-request-body-error-page-reentry.t
@@ -1,0 +1,173 @@
+#!/usr/bin/perl
+
+# Tests for Coraza-nginx connector: a request body carried through an
+# error_page re-entry into a coraza-on named location.
+#
+# When a non-Coraza error (here a plain 404) is routed through error_page,
+# nginx re-runs the rewrite and pre-access phases for the internal request
+# with r->error_page set.  On that second pass the pre-access handler must
+# yield at every intervention poll -- the final poll, and the in-loop polls
+# in both the in-memory and the file-buffered body paths -- rather than
+# finalizing the request a second time on top of the error page nginx is
+# already serving.  Phase-2 processing never runs on that pass, so a body
+# rule in the error_page location must not turn the 404 into a 403.
+#
+# The large body is bigger than client_body_buffer_size (temp file) and
+# bigger than the 64 KiB file chunk, so the file loop takes more than one
+# iteration and its in-loop poll site is actually exercised.
+#
+# The direct POST controls prove the body rule and both body paths work when
+# no error_page is involved, so the 404 outcomes above are not vacuous.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Socket qw/ CRLF /;
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http/);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        coraza on;
+        client_body_buffer_size 8k;
+        client_max_body_size 1m;
+
+        # Everything proxies to the backend below so the request reaches the
+        # content phase: `return` answers in the rewrite phase, before
+        # pre-access ever reads the body, and would make all of this vacuous.
+        # The URLENCODED body processor is what populates REQUEST_BODY.
+
+        # First pass: body is read and inspected clean, then the backend
+        # answers 404, which proxy_intercept_errors + error_page route into
+        # @fallback.
+        location /missing {
+            coraza_rules '
+                SecRuleEngine On
+                SecRequestBodyAccess On
+                SecRequestBodyLimit 1048576
+                SecAction "id:1,phase:1,pass,nolog,ctl:requestBodyProcessor=URLENCODED"
+            ';
+            proxy_intercept_errors on;
+            error_page 404 = @fallback;
+            proxy_pass http://127.0.0.1:8081;
+        }
+
+        # Second pass, r->error_page set.  The body rule here would fire if
+        # the connector re-inspected the body instead of yielding.
+        location @fallback {
+            coraza_rules '
+                SecRuleEngine On
+                SecRequestBodyAccess On
+                SecRequestBodyLimit 1048576
+                SecAction "id:1,phase:1,pass,nolog,ctl:requestBodyProcessor=URLENCODED"
+                SecRule REQUEST_BODY "@rx TRIGGER-BODY" "id:600,phase:2,deny,log,status:403"
+            ';
+            rewrite ^ /fallback break;
+            proxy_pass http://127.0.0.1:8081;
+        }
+
+        # Control: the same rule with no error_page in the way.
+        location /direct {
+            coraza_rules '
+                SecRuleEngine On
+                SecRequestBodyAccess On
+                SecRequestBodyLimit 1048576
+                SecAction "id:1,phase:1,pass,nolog,ctl:requestBodyProcessor=URLENCODED"
+                SecRule REQUEST_BODY "@rx TRIGGER-BODY" "id:601,phase:2,deny,log,status:403"
+            ';
+            proxy_pass http://127.0.0.1:8081;
+        }
+    }
+
+    server {
+        listen       127.0.0.1:8081;
+        server_name  backend;
+
+        coraza off;
+        default_type text/plain;
+
+        location /missing  { return 404; }
+        location /fallback { return 404 "fallback page\n"; }
+        location /direct   { return 200 "direct ok\n"; }
+    }
+}
+
+EOF
+
+$t->run();
+$t->todo_alerts();
+$t->plan(9);
+
+###############################################################################
+
+sub post {
+    my ($uri, $body) = @_;
+    return http(
+        "POST $uri HTTP/1.0" . CRLF
+        . "Host: localhost" . CRLF
+        . "Content-Type: application/x-www-form-urlencoded" . CRLF
+        . "Content-Length: " . length($body) . CRLF . CRLF
+        . $body
+    );
+}
+
+my $small = "a=leading+TRIGGER-BODY+trailing";
+my $large = "a=" . ("x" x 65536) . "TRIGGER-BODY" . ("y" x 131072);  # ~192 KiB
+
+# Controls first: the rule and both body paths work without error_page.
+like(post('/direct', $small), qr/^HTTP\S+ 403/,
+    'control: in-memory body trips the phase-2 rule on a direct request');
+like(post('/direct', $large), qr/^HTTP\S+ 403/,
+    'control: file-buffered multi-chunk body trips the phase-2 rule');
+like(post('/direct', "a=harmless"), qr/^HTTP\S+ 200/,
+    'control: clean body passes the direct location');
+
+# error_page re-entry, in-memory body.
+my $r = post('/missing', $small);
+like($r, qr/^HTTP\S+ 404/,
+    'in-memory body: error_page re-entry keeps the 404, not a second finalize');
+like($r, qr/fallback page/,
+    'in-memory body: error_page location body delivered on re-entry');
+
+# error_page re-entry, file-buffered body spanning more than one chunk.
+$r = post('/missing', $large);
+like($r, qr/^HTTP\S+ 404/,
+    'file body: error_page re-entry keeps the 404 across in-loop polls');
+like($r, qr/fallback page/,
+    'file body: error_page location body delivered on re-entry');
+
+# Worker survived all of it.
+like(http_get('/direct'), qr/^HTTP\S+ 200/, 'worker still serving afterwards');
+
+my $log = $t->read_file('error.log');
+unlike($log, qr/signal 11|SIGSEGV|AddressSanitizer/,
+    'no crash or sanitizer report in error.log');
+
+###############################################################################


### PR DESCRIPTION
The two in-loop intervention polls in the pre-access handler — one per chunk in the file-buffered body path, one per buffer in the in-memory path — had no `r->error_page` check. The final poll in the same function, and the sites in `rewrite.c`, `header_filter.c` and the body filter, all yield once nginx is already streaming the configured error page, so a fresh intervention raised on the error-page pass cannot finalize the request a second time. Both in-loop sites now yield the same way.

The file-path guard yields explicitly with `NGX_DECLINED` rather than jumping to the cleanup label with `rc` still `NGX_OK` — that shape would have reported the whole body inspected while the remaining chunks were never appended. The trailing `intervention_triggered` arming is exempted for that value, since none of the sibling sites arm the flag on a deliberate yield.

On the error-page pass the final poll already returned before `ngx_http_coraza_process_request_body_phase()`, so phase 2 never ran there. The earlier yields stop appending chunks that would not have been processed; they do not remove any inspection that used to happen.

## Three unrelated nits in the same area

- `coraza_rules` and `coraza_rules_file` declared `offset = offsetof(..., enable)`, which their handlers never read. Corrected to `0`, matching `coraza_transaction_id`.
- Removed the `lcf->rules == mmcf->rules` dedup branch in `init_process`. `mmcf->rules` is never populated, so it could not match; the real per-loc-conf dedup loop below it is unchanged.
- The log handler returned `NGX_ERROR` on a NULL ctx. LOG-phase handlers return `NGX_OK` by nginx contract.

## Testing

`t/coraza-request-body-error-page-reentry.t` routes a backend 404 into a `coraza on` named location whose phase-2 `REQUEST_BODY` rule would fire if the second pass re-inspected the body. Three body sizes: one that fits in the header preread (single buffer, `last_buf`, the in-memory loop breaks before its poll), a ~4 KiB one larger than what remains of the preread buffer but under `client_body_buffer_size` so nginx reads the rest into a second in-memory buffer and the in-memory in-loop poll runs, and one larger than `client_body_buffer_size` and the 64 KiB file chunk so the file loop's in-loop poll site actually iterates. `$request_body_file` in the access log pins the memory-versus-file split, so the two re-entry cases cannot silently exercise the same path. Direct POST controls prove the rule and all three body paths work without `error_page`. The test pins the observable contract — 404 served, no second finalize, worker healthy — not the internal poll ordering.

The in-loop yields are reached but not status-observable here, and the file header says so: phase-2 rules only run in the final process-request-body step, so the in-loop polls return 0 on the re-entry pass, and a deny on the first pass returns from the handler before the loop. Deleting the in-memory in-loop guard leaves the file green; the final poll's yield is what the 404 assertions pin.

Rebased onto #134, which renamed the file reader's cleanup label; the file-path yield jumps to `done` now.

Full suite against nginx 1.31.4 with libcoraza 1.7: 429 tests, all passing. Module builds clean under the CI `-Werror` flags.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed request-body inspection when requests re-enter through an `error_page` route.
  - Prevented previously handled requests from being finalized a second time, avoiding incorrect status changes such as turning a 404 into a 403.
  - Improved handling for both in-memory and file-buffered request bodies.
  - Ensured worker processes remain stable during these error-page flows.

- **Tests**
  - Added coverage for multi-chunk request bodies, error-page routing, and worker stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
