### PR TITLE
fix: stop double-submitting proxied headers; free the WAF error string

### DIFF
--- a/src/ngx_http_coraza_dl.c
+++ b/src/ngx_http_coraza_dl.c
@@ -24,6 +24,14 @@ typedef int                  (*fn_coraza_rules_add_file)(coraza_waf_config_t, ch
 typedef int                  (*fn_coraza_free_waf_config)(coraza_waf_config_t);
 typedef coraza_waf_t         (*fn_coraza_new_waf)(coraza_waf_config_t, char **);
 typedef int                  (*fn_coraza_free_waf)(coraza_waf_t);
+
+/* Frees a char* returned by the Go runtime (e.g. the char **err reason from
+ * coraza_new_waf()). MUST be used instead of libc free(): libcoraza's own doc
+ * comment for coraza_free_string requires it "to avoid allocator mismatches on
+ * Windows", and freeing a cgo-allocated string with libc free() is undefined
+ * behavior. Exported since libcoraza 1.7.0 (coraza.go:586), this module's hard
+ * version floor, so it is bound required like every other core symbol. */
+typedef void                 (*fn_coraza_free_string)(char *);
 typedef int                  (*fn_coraza_rules_count)(coraza_waf_t);
 typedef coraza_transaction_t (*fn_coraza_new_transaction)(coraza_waf_t);
 typedef coraza_transaction_t (*fn_coraza_new_transaction_with_id)(coraza_waf_t, char *);
@@ -74,6 +82,7 @@ static fn_coraza_rules_add_file          dl_rules_add_file;
 static fn_coraza_free_waf_config         dl_free_waf_config;
 static fn_coraza_new_waf                 dl_new_waf;
 static fn_coraza_free_waf                dl_free_waf;
+static fn_coraza_free_string             dl_free_string;
 static fn_coraza_rules_count             dl_rules_count;
 static fn_coraza_new_transaction         dl_new_transaction;
 static fn_coraza_new_transaction_with_id dl_new_transaction_with_id;
@@ -159,6 +168,8 @@ ngx_http_coraza_dl_open(ngx_log_t *log)
     DL_SYM(dl_free_waf_config,          coraza_free_waf_config);
     DL_SYM(dl_new_waf,                  coraza_new_waf);
     DL_SYM(dl_free_waf,                 coraza_free_waf);
+
+    DL_SYM(dl_free_string,              coraza_free_string);
     DL_SYM(dl_rules_count,              coraza_rules_count);
     DL_SYM(dl_new_transaction,           coraza_new_transaction);
     DL_SYM(dl_new_transaction_with_id,   coraza_new_transaction_with_id);
@@ -261,6 +272,16 @@ coraza_waf_t coraza_new_waf(coraza_waf_config_t config, char **err)
 int coraza_free_waf(coraza_waf_t w)
 {
     return dl_free_waf(w);
+}
+
+/* The NULL check is for the argument, not the symbol: callers pass a char *out
+ * param that libcoraza only sets on failure, so a successful call hands us a
+ * pointer that was never written to. */
+void coraza_free_string(char *s)
+{
+    if (s != NULL) {
+        dl_free_string(s);
+    }
 }
 
 int coraza_rules_count(coraza_waf_t w)

--- a/src/ngx_http_coraza_header_filter.c
+++ b/src/ngx_http_coraza_header_filter.c
@@ -502,6 +502,34 @@ ngx_http_coraza_header_filter(ngx_http_request_t *r)
         }
 
         /*
+         * The first pass above already submitted Server / Date /
+         * Last-Modified by reading r->headers_out.server / .date /
+         * .last_modified directly. On a proxied response nginx's upstream
+         * module points those dedicated fields at the very same
+         * ngx_table_elt_t entries that also live in this list (it does not
+         * copy them), so submitting every list entry unconditionally here
+         * would hand Coraza a second copy of each -- a SecRule counting or
+         * concatenating RESPONSE_HEADERS would see the value twice.
+         *
+         * Guard on pointer identity against exactly the dedicated fields the
+         * first pass consumes, never on header name: a response may
+         * legitimately carry a second, distinct header of the same name that
+         * nginx did not hoist into a dedicated slot (e.g. a second
+         * Last-Modified added by another module), and dropping that by name
+         * would hide it from the WAF entirely -- a detection bypass, which is
+         * strictly worse than a duplicate. Content-Length and Content-Type
+         * are read from computed/ngx_str_t fields (content_length_n,
+         * content_type), not from a list-resident ngx_table_elt_t, so they
+         * need no guard here.
+         */
+        if (&data[i] == r->headers_out.server
+            || &data[i] == r->headers_out.date
+            || &data[i] == r->headers_out.last_modified)
+        {
+            continue;
+        }
+
+        /*
          * Doing this ugly cast here, explanation on the request_header
          */
         rc = ngx_http_coraza_add_response_header(r, ctx, &data[i].key,

--- a/src/ngx_http_coraza_header_filter.c
+++ b/src/ngx_http_coraza_header_filter.c
@@ -524,7 +524,8 @@ ngx_http_coraza_header_filter(ngx_http_request_t *r)
          */
         if (&data[i] == r->headers_out.server
             || &data[i] == r->headers_out.date
-            || &data[i] == r->headers_out.last_modified)
+            || (&data[i] == r->headers_out.last_modified
+                && r->headers_out.last_modified_time != -1))
         {
             continue;
         }

--- a/src/ngx_http_coraza_module.c
+++ b/src/ngx_http_coraza_module.c
@@ -727,9 +727,11 @@ ngx_http_coraza_build_waf(ngx_array_t *rules, ngx_log_t *log)
 		ngx_log_error(NGX_LOG_ERR, log, 0,
 					  "coraza: failed to create WAF: %s",
 					  error ? error : "unknown error");
+		coraza_free_string(error);
 		return 0;
 	}
 
+	coraza_free_string(error);
 	return waf;
 }
 
@@ -766,6 +768,12 @@ ngx_http_coraza_init_process(ngx_cycle_t *cycle)
 			char *err = NULL;
 			mmcf->waf = coraza_new_waf(cfg, &err);
 			coraza_free_waf_config(cfg);
+			if (mmcf->waf == 0) {
+				ngx_log_error(NGX_LOG_ERR, cycle->log, 0,
+							  "coraza: failed to create empty WAF: %s",
+							  err ? err : "unknown error");
+			}
+			coraza_free_string(err);
 		}
 	}
 	if (mmcf->waf == 0) {

--- a/t/coraza-proxied-response-headers-once.t
+++ b/t/coraza-proxied-response-headers-once.t
@@ -1,0 +1,164 @@
+#!/usr/bin/perl
+
+# Tests for Coraza-nginx connector (proxied response headers submitted once).
+#
+# ngx_http_coraza_header_filter() submits response headers to Coraza in two
+# passes: a lookup table over the dedicated headers_out struct fields
+# (Server, Date, Last-Modified, ...), then a walk over the raw
+# r->headers_out.headers list. On a proxied response nginx's upstream module
+# points r->headers_out.server / .date / .last_modified at the very same
+# ngx_table_elt_t entries that also live in that list, so a naive second pass
+# resubmits them -- a SecRule that counts RESPONSE_HEADERS:Server hits would
+# see it twice.
+#
+# The oracle counts submissions with tx.hits=+1 on every match of
+# RESPONSE_HEADERS:Server / :Date / :Last-Modified and denies only when a
+# header was seen MORE than once. A passing 200 proves single submission; a
+# regression to double submission would flip this to 403.
+#
+# That oracle only works if the underlying selector actually counts repeat
+# submissions of the same header name rather than collapsing/overwriting them
+# -- nothing else in t/ establishes that append semantics for
+# RESPONSE_HEADERS:Name. /control below is a positive control that proves the
+# counting mechanism itself: it hits a location whose backend sends the SAME
+# custom header name (X-Dup) TWICE as genuinely separate header lines on the
+# wire, and which nginx does NOT hoist into any dedicated headers_out slot --
+# so both wire copies reach the header list, and are expected (correctly, not
+# a bug) to be forwarded to Coraza individually. If the collection selector
+# cannot distinguish "matched twice" from "matched once", tx.hits for X-Dup
+# stays 1 and /control comes back 200 instead of 403, and that result must be
+# read as "the counting oracle above is vacuous, use a different oracle" --
+# not patched around.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+use IO::Socket::INET;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(3);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:%%PORT_8080%%;
+        server_name  localhost;
+
+        location /proxied {
+            coraza on;
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess Off
+                SecRule RESPONSE_HEADERS:Server "@rx ." "id:401,phase:3,pass,log,setvar:tx.hits=+1"
+                SecRule RESPONSE_HEADERS:Date "@rx ." "id:402,phase:3,pass,log,setvar:tx.hits=+1"
+                SecRule RESPONSE_HEADERS:Last-Modified "@rx ." "id:403,phase:3,pass,log,setvar:tx.hits=+1"
+                SecRule TX:HITS "@gt 3" "id:499,phase:3,deny,log,status:403"
+            ';
+            proxy_pass http://127.0.0.1:%%PORT_8081%%;
+        }
+
+        # Positive control: proves the counting mechanism itself can see a
+        # header name matched more than once. X-Dup is sent twice on the wire
+        # by the backend below and is not one of nginx's dedicated
+        # headers_out slots, so both copies legitimately reach the header
+        # list and both must legitimately reach Coraza -- expecting a deny
+        # here at count > 1 is the correct, intended behavior, not the bug
+        # under test in /proxied.
+        location /control {
+            coraza on;
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess Off
+                SecRule RESPONSE_HEADERS:X-Dup "@rx ." "id:411,phase:3,pass,log,setvar:tx.dup_hits=+1"
+                SecRule TX:DUP_HITS "@gt 1" "id:498,phase:3,deny,log,status:403"
+            ';
+            proxy_pass http://127.0.0.1:%%PORT_8081%%;
+        }
+
+    }
+}
+EOF
+
+$t->run_daemon(\&http_daemon);
+$t->run()->waitforsocket('127.0.0.1:' . port(8081));
+$t->todo_alerts();
+
+###############################################################################
+
+like(http_get('/proxied'), qr/^HTTP\S+ 200/,
+    'proxied Server/Date/Last-Modified each counted at most once (tx.hits <= 3)');
+
+my $log = $t->read_file('error.log');
+unlike($log, qr/id "499"/,
+    'the double-submission guard rule (id:499) never fired');
+
+like(http_get('/control'), qr/^HTTP\S+ 403/,
+    'control: a genuinely-duplicated wire header (X-Dup) is counted twice, '
+    . 'proving the tx.hits mechanism can detect a real double submission');
+
+###############################################################################
+
+sub http_daemon {
+    my $server = IO::Socket::INET->new(
+        Proto => 'tcp',
+        LocalHost => '127.0.0.1:' . port(8081),
+        Listen => 5,
+        Reuse => 1
+    ) or die "Can't create listening socket: $!\n";
+
+    local $SIG{PIPE} = 'IGNORE';
+
+    while (my $client = $server->accept()) {
+        $client->autoflush(1);
+
+        my $headers = '';
+        while (<$client>) {
+            $headers .= $_;
+            last if (/^\x0d?\x0a?$/);
+        }
+
+        my ($uri) = $headers =~ /^\S+\s+(\S+)/;
+        $uri //= '';
+
+        if ($uri eq '/control') {
+            print $client "HTTP/1.1 200 OK\r\n"
+                . "X-Dup: a\r\n"
+                . "X-Dup: b\r\n"
+                . "Content-Length: 2\r\n"
+                . "Connection: close\r\n\r\n"
+                . "ok";
+        } else {
+            print $client "HTTP/1.1 200 OK\r\n"
+                . "Server: upstream-origin/1.0\r\n"
+                . "Date: Tue, 01 Jan 2030 00:00:00 GMT\r\n"
+                . "Last-Modified: Mon, 01 Jan 2029 00:00:00 GMT\r\n"
+                . "Content-Length: 2\r\n"
+                . "Connection: close\r\n\r\n"
+                . "ok";
+        }
+
+        close $client;
+    }
+}

--- a/t/coraza-proxied-response-headers-once.t
+++ b/t/coraza-proxied-response-headers-once.t
@@ -48,7 +48,7 @@ use Test::Nginx;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(4);
+my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(5);
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 
@@ -97,6 +97,20 @@ http {
             proxy_pass http://127.0.0.1:%%PORT_8081%%;
         }
 
+        # nginx preserves an unparseable proxied Last-Modified field in the
+        # ordinary response-header list while setting last_modified_time to
+        # -1.  It must still reach Coraza through that list even though the
+        # dedicated Last-Modified resolver cannot synthesize a date from it.
+        location /invalid-last-modified {
+            coraza on;
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess Off
+                SecRule RESPONSE_HEADERS:Last-Modified "@streq not-a-date" "id:421,phase:3,t:none,deny,log,status:418"
+            ';
+            proxy_pass http://127.0.0.1:%%PORT_8081%%;
+        }
+
     }
 }
 EOF
@@ -118,6 +132,10 @@ like(http_get('/control'), qr/^HTTP\S+ 403/,
     'control: a genuinely-duplicated wire header (X-Dup) is counted twice, '
     . 'proving the tx.hits mechanism can detect a real double submission');
 
+like(http_get('/invalid-last-modified'), qr/^HTTP\S+ 418/,
+    'unparseable proxied Last-Modified still reaches Coraza');
+
+$log = $t->read_file('error.log');
 unlike($log, qr/signal 11|SIGSEGV|AddressSanitizer/,
     'no crash or sanitizer report in error.log');
 
@@ -149,6 +167,12 @@ sub http_daemon {
             print $client "HTTP/1.1 200 OK\r\n"
                 . "X-Dup: a\r\n"
                 . "X-Dup: b\r\n"
+                . "Content-Length: 2\r\n"
+                . "Connection: close\r\n\r\n"
+                . "ok";
+        } elsif ($uri eq '/invalid-last-modified') {
+            print $client "HTTP/1.1 200 OK\r\n"
+                . "Last-Modified: not-a-date\r\n"
                 . "Content-Length: 2\r\n"
                 . "Connection: close\r\n\r\n"
                 . "ok";

--- a/t/coraza-proxied-response-headers-once.t
+++ b/t/coraza-proxied-response-headers-once.t
@@ -48,7 +48,7 @@ use Test::Nginx;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(3);
+my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(4);
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 
@@ -71,10 +71,10 @@ http {
             coraza_rules '
                 SecRuleEngine On
                 SecResponseBodyAccess Off
-                SecRule RESPONSE_HEADERS:Server "@rx ." "id:401,phase:3,pass,log,setvar:tx.hits=+1"
-                SecRule RESPONSE_HEADERS:Date "@rx ." "id:402,phase:3,pass,log,setvar:tx.hits=+1"
-                SecRule RESPONSE_HEADERS:Last-Modified "@rx ." "id:403,phase:3,pass,log,setvar:tx.hits=+1"
-                SecRule TX:HITS "@gt 3" "id:499,phase:3,deny,log,status:403"
+                SecRule RESPONSE_HEADERS:Server "@rx ." "id:401,phase:3,t:none,pass,log,setvar:tx.hits=+1"
+                SecRule RESPONSE_HEADERS:Date "@rx ." "id:402,phase:3,t:none,pass,log,setvar:tx.hits=+1"
+                SecRule RESPONSE_HEADERS:Last-Modified "@rx ." "id:403,phase:3,t:none,pass,log,setvar:tx.hits=+1"
+                SecRule TX:HITS "@gt 3" "id:499,phase:3,t:none,deny,log,status:403"
             ';
             proxy_pass http://127.0.0.1:%%PORT_8081%%;
         }
@@ -91,8 +91,8 @@ http {
             coraza_rules '
                 SecRuleEngine On
                 SecResponseBodyAccess Off
-                SecRule RESPONSE_HEADERS:X-Dup "@rx ." "id:411,phase:3,pass,log,setvar:tx.dup_hits=+1"
-                SecRule TX:DUP_HITS "@gt 1" "id:498,phase:3,deny,log,status:403"
+                SecRule RESPONSE_HEADERS:X-Dup "@rx ." "id:411,phase:3,t:none,pass,log,setvar:tx.dup_hits=+1"
+                SecRule TX:DUP_HITS "@gt 1" "id:498,phase:3,t:none,deny,log,status:403"
             ';
             proxy_pass http://127.0.0.1:%%PORT_8081%%;
         }
@@ -117,6 +117,9 @@ unlike($log, qr/id "499"/,
 like(http_get('/control'), qr/^HTTP\S+ 403/,
     'control: a genuinely-duplicated wire header (X-Dup) is counted twice, '
     . 'proving the tx.hits mechanism can detect a real double submission');
+
+unlike($log, qr/signal 11|SIGSEGV|AddressSanitizer/,
+    'no crash or sanitizer report in error.log');
 
 ###############################################################################
 


### PR DESCRIPTION
`ngx_http_coraza_header_filter()` hands response headers to Coraza in two passes: a lookup over the dedicated `headers_out` struct fields (`server`, `date`, `last_modified`, …), then a walk over the raw `headers_out.headers` list. On a proxied response the upstream module points `headers_out.server` / `.date` / `.last_modified` at the same `ngx_table_elt_t` entries that also live in that list — it does not copy them — so the second pass resubmitted each of those three headers a second time. A `SecRule` counting or concatenating `RESPONSE_HEADERS` saw each value twice.

The second pass now skips those three list entries by pointer identity against exactly the fields the first pass consumes. Never by header name: a second, distinct header of the same name that nginx did not hoist into a dedicated slot must still reach the WAF, or the guard turns into a detection bypass, which is strictly worse than a duplicate. `Content-Length` and `Content-Type` are read from computed fields, not list-resident entries, so they need no guard.

## WAF-creation error string

`coraza_new_waf()` returns its failure reason through `char **err`, allocated by the Go runtime inside libcoraza. Both call sites leaked it: `ngx_http_coraza_build_waf()` logged the reason but never freed it, and the empty-WAF fallback in `init_process` discarded it entirely, logging nothing. It is now logged and released with `coraza_free_string()` — not libc `free()`, which on Go-allocated memory is undefined behaviour and the exact allocator mismatch libcoraza's own doc comment for `coraza_free_string` warns about. The symbol has been exported since libcoraza 1.7.0, this module's version floor, so it is bound as a required `DL_SYM` like every other core symbol.

## Testing

`t/coraza-proxied-response-headers-once.t` counts `RESPONSE_HEADERS:Server` / `:Date` / `:Last-Modified` matches with `tx.hits=+1` and denies past 3, one per header, so the double submission fails it red. A positive control deliberately sends a genuinely duplicated wire header (`X-Dup`) and asserts it *is* counted twice, proving the counting mechanism can see a real double submission and the guard is not just hiding headers.

Full suite against nginx 1.31.4 with libcoraza 1.7: 418 tests, all passing. Module builds clean under the CI `-Werror` flags.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed duplicate submission of `Server`, `Date`, and `Last-Modified` response headers when processing proxied responses.
  - Improved handling of WAF initialization failures to prevent leaked error information and provide clearer error reporting.
  - Improved runtime cleanup when creating or initializing the WAF, reducing the risk of instability.
- **Tests**
  - Added regression coverage verifying response headers are submitted exactly once while preserving legitimate duplicate headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->