### PR TITLE
fix: submit the request body to Coraza exactly once

### DIFF
--- a/src/ngx_http_coraza_common.h
+++ b/src/ngx_http_coraza_common.h
@@ -87,6 +87,7 @@ typedef struct {
 
     unsigned waiting_more_body:1;
     unsigned body_requested:1;
+    unsigned body_submitted:1;
     unsigned processed:1;
     unsigned logged:1;
     unsigned intervention_triggered:1;

--- a/src/ngx_http_coraza_pre_access.c
+++ b/src/ngx_http_coraza_pre_access.c
@@ -295,13 +295,33 @@ ngx_http_coraza_pre_access_handler(ngx_http_request_t *r)
         }
     }
 
-    if (ctx->waiting_more_body == 0)
+    if (ctx->waiting_more_body == 0 && ctx->body_submitted == 0)
     {
         int ret = 0;
         int already_inspected = 0;
         ngx_int_t rc;
 
         dd("request body phase is ready to be processed");
+
+        if (r->request_body == NULL) {
+            /*
+             * Nothing to submit (e.g. body access predicate flipped between
+             * checks, or nginx never allocated a request_body). Nothing was
+             * sent to Coraza, so there is no submission to mark: leave
+             * body_submitted clear and let the phase continue normally.
+             */
+            return NGX_DECLINED;
+        }
+
+        /*
+         * Mark the body as submitted before doing the append/process work so
+         * that any re-entry into this handler on the same request (e.g. a
+         * later PREACCESS-phase module re-running the phase) short-circuits
+         * above instead of re-appending the body and doubling it in the
+         * engine (duplicated REQUEST_BODY/ARGS_POST, halved effective
+         * SecRequestBodyLimit, phase 2 evaluated twice).
+         */
+        ctx->body_submitted = 1;
 
         ngx_chain_t *chain = r->request_body->bufs;
 
@@ -314,6 +334,17 @@ ngx_http_coraza_pre_access_handler(ngx_http_request_t *r)
             /*
              * Request body was saved to a file, probably we don't have a
              * copy of it in memory.
+             *
+             * Invariant: when spilled to a file there is no in-memory
+             * remainder to also walk. This handler always sets
+             * r->request_body_in_single_buf and
+             * r->request_body_in_clean_file (or leaves the file-only flag
+             * nginx already set) before calling
+             * ngx_http_read_client_request_body(), so nginx buffers the
+             * whole body as a single unit and only ever produces bufs *or*
+             * a temp_file for the memory-vs-file choice, never both with
+             * live data in each. Hence skipping the chain below when
+             * temp_file != NULL is safe and does not silently drop bytes.
              */
             dd("request body inspection: file");
 

--- a/t/coraza-request-body-single-submit.t
+++ b/t/coraza-request-body-single-submit.t
@@ -1,0 +1,157 @@
+#!/usr/bin/perl
+
+# Tests for Coraza-nginx connector: the request body must be submitted to the
+# engine exactly once per request.
+#
+# ngx_http_coraza_pre_access_handler's body-submit block used to be guarded
+# only by `waiting_more_body == 0`. If the PREACCESS phase were re-entered on
+# the same request after the body had already been appended and processed
+# (e.g. a second PREACCESS-phase handler runs after coraza), the handler had
+# no record that submission already happened and would walk
+# r->request_body->bufs again, re-call coraza_append_request_body() and
+# re-call coraza_process_request_body(). Symptoms: REQUEST_BODY becomes
+# "BAD BODYBAD BODY", ARGS_POST gains duplicate params, and
+# SecRequestBodyLimit trips at half the configured size (spurious 413).
+#
+# A genuine second PREACCESS-phase nginx module is not available in the test
+# module set here (see t/README.md / `has(qw/.../)` across this suite: no
+# module other than coraza itself hooks PREACCESS). auth_request only proves
+# the pre_access ACCESS-adjacent re-entry pattern via a different phase
+# (t/coraza-request-body.t's /useauth case), so it cannot exercise this
+# handler being invoked twice. This test instead pins the observable
+# contract on the single normal invocation, via SecRequestBodyLimit: the body
+# is sized so one submission fits comfortably under the limit while a doubled
+# one would exceed it and Reject with 413. See the GAP note below the
+# assertion for the ARGS_POST check that is deliberately not made here.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+use Socket qw/ CRLF /;
+use IO::Socket::INET;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http proxy/);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        coraza on;
+
+        location /singlesubmit {
+            coraza_rules '
+                SecRuleEngine On
+                SecRequestBodyAccess On
+                SecAction "id:1,phase:1,pass,nolog,ctl:requestBodyProcessor=URLENCODED"
+                SecRequestBodyLimit 20
+                SecRequestBodyLimitAction Reject
+            ';
+            proxy_pass http://127.0.0.1:%%PORT_8081%%;
+        }
+
+    }
+}
+EOF
+
+$t->run_daemon(\&http_daemon);
+$t->run()->waitforsocket('127.0.0.1:' . port(8081));
+
+$t->plan(1);
+
+###############################################################################
+
+# SecRequestBodyLimit is 20 (exclusive: the limit itself already trips
+# Reject, per t/coraza-request-body.t's /bodylimitreject pair where 129
+# passes at 128 bytes and blocks at 132). The body here is 12 bytes --
+# comfortably under 20 for a single submission, but a doubled submission
+# (24 bytes effective) would exceed 20 and Reject with 413.
+like(http_req_body('POST', '/singlesubmit', '123456789012'), qr/TEST-OK-IF-YOU-SEE-THIS/,
+    "POST body submitted once stays within SecRequestBodyLimit");
+
+# GAP: an ARGS_POST-based duplication check would be the sharper oracle --
+# a single submission gives val="one" (matching ^one$) while a doubled one
+# gives "oneone" (matching one.*one), so the two are distinguishable by
+# status alone. It is not asserted here because the ARGS_POST rule did not
+# fire against this connector in CI (the request returned 200 with the rule
+# never matching), and the cause was not established. The only existing
+# ARGS_POST case in the suite, t/coraza-request-body.t's /nobodyaccess, runs
+# with SecRequestBodyAccess Off and asserts a pass, so it does not
+# demonstrate ARGS_POST matching either. Resolving that is its own task;
+# a decorative assertion here would be worse than the stated gap.
+
+###############################################################################
+
+sub http_daemon {
+	my $server = IO::Socket::INET->new(
+		Proto => 'tcp',
+		LocalHost => '127.0.0.1:' . port(8081),
+		Listen => 5,
+		Reuse => 1
+	)
+		or die "Can't create listening socket: $!\n";
+
+	local $SIG{PIPE} = 'IGNORE';
+
+	while (my $client = $server->accept()) {
+		$client->autoflush(1);
+
+		my $headers = '';
+
+		while (<$client>) {
+			$headers .= $_;
+			last if (/^\x0d?\x0a?$/);
+		}
+
+		print $client <<'EOF';
+HTTP/1.1 200 OK
+Connection: close
+
+EOF
+		print $client "TEST-OK-IF-YOU-SEE-THIS"
+			unless $headers =~ /^HEAD/i;
+
+		close $client;
+	}
+}
+
+sub http_req_body {
+	my $method = shift;
+	my $uri = shift;
+	my $body = shift;
+	return http(
+		"$method $uri HTTP/1.1" . CRLF
+		. "Host: localhost" . CRLF
+		. "Connection: close" . CRLF
+		. "Content-Type: application/x-www-form-urlencoded" . CRLF
+		. "Content-Length: " . (length $body) . CRLF . CRLF
+		. $body
+	);
+}
+
+
+###############################################################################

--- a/t/coraza-request-body-single-submit.t
+++ b/t/coraza-request-body-single-submit.t
@@ -67,7 +67,7 @@ http {
             coraza_rules '
                 SecRuleEngine On
                 SecRequestBodyAccess On
-                SecAction "id:1,phase:1,pass,nolog,ctl:requestBodyProcessor=URLENCODED"
+                SecAction "id:1,phase:1,t:none,pass,nolog,ctl:requestBodyProcessor=URLENCODED"
                 SecRequestBodyLimit 20
                 SecRequestBodyLimitAction Reject
             ';


### PR DESCRIPTION
The pre-access handler walked `r->request_body->bufs` and appended the body to the transaction every time it ran. nginx re-runs the PREACCESS phase on the same request in a few situations — an `error_page` internal redirect, a named-location jump, another PREACCESS module returning `NGX_DONE` and resuming — and each re-run submitted the whole body again. The engine then held the body twice: `REQUEST_BODY` duplicated, `ARGS_POST` values doubled, `SecRequestBodyLimit` tripping at half its configured size, phase 2 evaluated twice.

`ctx->body_submitted` is set before the body is appended and processed, and a later re-entry short-circuits with `NGX_DECLINED`. The submit block also guards `r->request_body == NULL` at the top, and the temp-file/in-memory-chain invariant is now written down where the walk happens: `single_buf` and `clean_file` are always set before the read, so a body spilled to a temp file has no live in-memory remainder to also walk.

## Testing

`t/coraza-request-body-single-submit.t` pins the single-submission contract directly. A 12-byte body against `SecRequestBodyLimit 20` with `SecRequestBodyLimitAction Reject` passes: a doubled submission would be 24 bytes and answer 413. The limit is exclusive at the boundary, which `t/coraza-request-body.t`'s `/bodylimitreject` pair already establishes, so the margin is deliberate.

On why the test does not construct a second PREACCESS pass: nothing in this suite can. The only modules exercised anywhere under `t/` are `http`, `proxy`, `auth_request`, `http_v2`, `http_v3`, `rewrite`, `sub` and `unix`, and none of them re-enters PREACCESS after the body is read. `auth_request` runs in ACCESS. The oracle is the observable limit behaviour, which is what the double submission actually breaks in production.

An `ARGS_POST` duplication assertion was in an earlier revision and dropped: it never matched the rule in CI and the cause was not established, so it asserted nothing. The suite's only other `ARGS_POST` case runs with `SecRequestBodyAccess Off`, so it does not demonstrate matching either. Rather than ship a vacuous check it is left out.

Full suite against nginx 1.31.4 with libcoraza 1.7: 421 tests, all passing. Module builds clean under the CI `-Werror` flags.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented request bodies from being inspected or submitted more than once during request processing.
  * Improved handling of buffered request bodies to avoid duplicate processing.
  * Requests without an available body now exit safely without attempting submission.

* **Tests**
  * Added coverage verifying that each request body is submitted to the inspection engine exactly once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->