### PR TITLE
test(h2): run the phase-4 blocking assertions in CI; document coraza_delay_response_headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ Or, to build a dynamic module:
 Note that when building a dynamic module, your nginx source version
 needs to match the version of nginx you're compiling this for.
 
+When building from source, pass `-Wno-unused-function`. The installed
+`coraza/coraza.h` carries libcoraza's cgo preamble, whose `static` callback
+shims are unused in any given translation unit, and nginx builds with `-Werror`:
+
+```
+./configure --add-dynamic-module=/path/to/coraza-nginx --with-compat \
+    --with-cc-opt="-Wno-unused-function"
+```
+
+The Debian package build sets its own CFLAGS and does not need this flag.
+
 Further information about nginx third-party add-ons support are available here:
 http://wiki.nginx.org/3rdPartyModules
 
@@ -83,7 +94,7 @@ sets `-ldl` for you on Linux/macOS.
 # Usage
 
 coraza for nginx extends your nginx configuration directives.
-It adds four new directives:
+It adds five new directives:
 
 coraza
 ------
@@ -191,6 +202,21 @@ be able to find correlations between access log and error log entries
 using the same unique identificator.
 
 String can contain variables.
+
+coraza_delay_response_headers
+-----------------------------
+**syntax:** *coraza_delay_response_headers on | off*
+
+**context:** *http, server, location*
+
+**default:** *on*
+
+When enabled (the default), response headers are held back from the client
+until phase-4 response body inspection completes, so a phase-4 rule can still
+return a clean error page. When disabled, headers are sent as soon as they are
+ready, which means a late phase-4 intervention can no longer replace a response
+whose headers have already gone out. Operators whose ruleset has no phase-4
+response rules can turn this off to restore normal header streaming.
 
 ## Configuration merging
 

--- a/README.md
+++ b/README.md
@@ -203,8 +203,7 @@ using the same unique identificator.
 
 String can contain variables.
 
-coraza_delay_response_headers
------------------------------
+## coraza_delay_response_headers
 **syntax:** *coraza_delay_response_headers on | off*
 
 **context:** *http, server, location*
@@ -351,5 +350,4 @@ feel free to open GitHub issues requesting for new features. Before opening a ne
 
 Having our packages in distros on time is something we highly desire. Let us know if
 there is anything we can do to facilitate your work as a packager.
-
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ When building from source, pass `-Wno-unused-function`. The installed
 `coraza/coraza.h` carries libcoraza's cgo preamble, whose `static` callback
 shims are unused in any given translation unit, and nginx builds with `-Werror`:
 
-```
+```sh
 ./configure --add-dynamic-module=/path/to/coraza-nginx --with-compat \
     --with-cc-opt="-Wno-unused-function"
 ```

--- a/t/coraza-h2.t
+++ b/t/coraza-h2.t
@@ -98,7 +98,7 @@ $t->write_file("/phase2", "should be moved/blocked before this.");
 $t->write_file("/phase3", "should be moved/blocked before this.");
 $t->write_file("/phase4", "should not be moved/blocked, headers delivered before phase 4.");
 $t->run();
-$t->plan(20);
+$t->plan(24);
 
 ###############################################################################
 
@@ -114,15 +114,13 @@ for $phase (1 .. 3) {
 	is($frame->{headers}->{':status'}, 302, "redirect 302 - phase ${phase}");
 }
 
-SKIP: {
-skip 'long test', 1 unless $ENV{TEST_NGINX_UNSAFE};
-
 $s = Test::Nginx::HTTP2->new();
 $sid = $s->new_stream({ path => '/phase4?what=redirect302' });
 $frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
+is($frame->{headers}->{':status'}, 302, 'redirect 302 - phase 4 status');
 ($frame) = grep { $_->{type} eq "DATA" } @$frames;
-is($frame, undef, 'redirect 302 - phase 4');
-}
+unlike($frame->{data} // '', qr/should not be moved/, 'redirect 302 - phase 4 body not leaked');
 
 # Redirect (301)
 
@@ -134,15 +132,13 @@ for $phase (1 .. 3) {
 	is($frame->{headers}->{':status'}, 301, "redirect 301 - phase ${phase}");
 }
 
-SKIP: {
-skip 'long test', 1 unless $ENV{TEST_NGINX_UNSAFE};
-
 $s = Test::Nginx::HTTP2->new();
 $sid = $s->new_stream({ path => '/phase4?what=redirect301' });
 $frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
+is($frame->{headers}->{':status'}, 301, 'redirect 301 - phase 4 status');
 ($frame) = grep { $_->{type} eq "DATA" } @$frames;
-is($frame, undef, 'redirect 301 - phase 4');
-}
+unlike($frame->{data} // '', qr/should not be moved/, 'redirect 301 - phase 4 body not leaked');
 
 # Block (401)
 
@@ -154,15 +150,13 @@ for $phase (1 .. 3) {
 	is($frame->{headers}->{':status'}, 401, "block 401 - phase ${phase}");
 }
 
-SKIP: {
-skip 'long test', 1 unless $ENV{TEST_NGINX_UNSAFE};
-
 $s = Test::Nginx::HTTP2->new();
 $sid = $s->new_stream({ path => '/phase4?what=block401' });
 $frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
+is($frame->{headers}->{':status'}, 401, 'block 401 - phase 4 status');
 ($frame) = grep { $_->{type} eq "DATA" } @$frames;
-is($frame, undef, 'block 401 - phase 4');
-}
+unlike($frame->{data} // '', qr/should not be moved/, 'block 401 - phase 4 body not leaked');
 
 # Block (403)
 
@@ -174,15 +168,13 @@ for $phase (1 .. 3) {
 	is($frame->{headers}->{':status'}, 403, "block 403 - phase ${phase}");
 }
 
-SKIP: {
-skip 'long test', 1 unless $ENV{TEST_NGINX_UNSAFE};
-
 $s = Test::Nginx::HTTP2->new();
 $sid = $s->new_stream({ path => '/phase4?what=block403' });
 $frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
+is($frame->{headers}->{':status'}, 403, 'block 403 - phase 4 status');
 ($frame) = grep { $_->{type} eq "DATA" } @$frames;
-is($frame, undef, 'block 403 - phase 4');
-}
+unlike($frame->{data} // '', qr/should not be moved/, 'block 403 - phase 4 body not leaked');
 
 # Nothing to detect
 

--- a/t/coraza-h2.t
+++ b/t/coraza-h2.t
@@ -102,7 +102,7 @@ $t->plan(24);
 
 ###############################################################################
 
-my ($phase, $s, $sid, $frames, $frame);
+my ($phase, $s, $sid, $frames, $frame, $data);
 
 # Redirect (302)
 
@@ -119,8 +119,9 @@ $sid = $s->new_stream({ path => '/phase4?what=redirect302' });
 $frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 302, 'redirect 302 - phase 4 status');
-($frame) = grep { $_->{type} eq "DATA" } @$frames;
-unlike($frame->{data} // '', qr/should not be moved/, 'redirect 302 - phase 4 body not leaked');
+$data = join '', map { $_->{data} // '' }
+	grep { $_->{type} eq "DATA" } @$frames;
+unlike($data, qr/should not be moved/, 'redirect 302 - phase 4 body not leaked');
 
 # Redirect (301)
 
@@ -137,8 +138,9 @@ $sid = $s->new_stream({ path => '/phase4?what=redirect301' });
 $frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 301, 'redirect 301 - phase 4 status');
-($frame) = grep { $_->{type} eq "DATA" } @$frames;
-unlike($frame->{data} // '', qr/should not be moved/, 'redirect 301 - phase 4 body not leaked');
+$data = join '', map { $_->{data} // '' }
+	grep { $_->{type} eq "DATA" } @$frames;
+unlike($data, qr/should not be moved/, 'redirect 301 - phase 4 body not leaked');
 
 # Block (401)
 
@@ -155,8 +157,9 @@ $sid = $s->new_stream({ path => '/phase4?what=block401' });
 $frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 401, 'block 401 - phase 4 status');
-($frame) = grep { $_->{type} eq "DATA" } @$frames;
-unlike($frame->{data} // '', qr/should not be moved/, 'block 401 - phase 4 body not leaked');
+$data = join '', map { $_->{data} // '' }
+	grep { $_->{type} eq "DATA" } @$frames;
+unlike($data, qr/should not be moved/, 'block 401 - phase 4 body not leaked');
 
 # Block (403)
 
@@ -173,8 +176,9 @@ $sid = $s->new_stream({ path => '/phase4?what=block403' });
 $frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 403, 'block 403 - phase 4 status');
-($frame) = grep { $_->{type} eq "DATA" } @$frames;
-unlike($frame->{data} // '', qr/should not be moved/, 'block 403 - phase 4 body not leaked');
+$data = join '', map { $_->{data} // '' }
+	grep { $_->{type} eq "DATA" } @$frames;
+unlike($data, qr/should not be moved/, 'block 403 - phase 4 body not leaked');
 
 # Nothing to detect
 

--- a/t/coraza-proxy-h2.t
+++ b/t/coraza-proxy-h2.t
@@ -23,7 +23,7 @@ use Test::Nginx::HTTP2;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http http_v2 proxy/)->plan(23);
+my $t = Test::Nginx->new()->has(qw/http http_v2 proxy/)->plan(27);
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 
@@ -135,15 +135,13 @@ for $phase (1 .. 3) {
 	is($frame->{headers}->{':status'}, 302, "redirect 302 - phase ${phase}");
 }
 
-SKIP: {
-skip 'long test', 1 unless $ENV{TEST_NGINX_UNSAFE};
-
 $s = Test::Nginx::HTTP2->new();
 $sid = $s->new_stream({ path => '/phase4?what=redirect302' });
 $frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
+is($frame->{headers}->{':status'}, 302, 'redirect 302 - phase 4 status');
 ($frame) = grep { $_->{type} eq "DATA" } @$frames;
-is($frame, undef, 'redirect 302 - phase 4');
-}
+unlike($frame->{data} // '', qr/not found/, 'redirect 302 - phase 4 body not leaked');
 
 # Redirect (301)
 
@@ -155,15 +153,13 @@ for $phase (1 .. 3) {
 	is($frame->{headers}->{':status'}, 301, "redirect 301 - phase ${phase}");
 }
 
-SKIP: {
-skip 'long test', 1 unless $ENV{TEST_NGINX_UNSAFE};
-
 $s = Test::Nginx::HTTP2->new();
 $sid = $s->new_stream({ path => '/phase4?what=redirect301' });
 $frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
+is($frame->{headers}->{':status'}, 301, 'redirect 301 - phase 4 status');
 ($frame) = grep { $_->{type} eq "DATA" } @$frames;
-is($frame, undef, 'redirect 301 - phase 4');
-}
+unlike($frame->{data} // '', qr/not found/, 'redirect 301 - phase 4 body not leaked');
 
 # Block (401)
 
@@ -175,15 +171,13 @@ for $phase (1 .. 3) {
 	is($frame->{headers}->{':status'}, 401, "block 401 - phase ${phase}");
 }
 
-SKIP: {
-skip 'long test', 1 unless $ENV{TEST_NGINX_UNSAFE};
-
 $s = Test::Nginx::HTTP2->new();
 $sid = $s->new_stream({ path => '/phase4?what=block401' });
 $frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
+is($frame->{headers}->{':status'}, 401, 'block 401 - phase 4 status');
 ($frame) = grep { $_->{type} eq "DATA" } @$frames;
-is($frame, undef, 'block 401 - phase 4');
-}
+unlike($frame->{data} // '', qr/not found/, 'block 401 - phase 4 body not leaked');
 
 
 # Block (403)
@@ -196,15 +190,13 @@ for $phase (1 .. 3) {
 	is($frame->{headers}->{':status'}, 403, "block 403 - phase ${phase}");
 }
 
-SKIP: {
-skip 'long test', 1 unless $ENV{TEST_NGINX_UNSAFE};
-
 $s = Test::Nginx::HTTP2->new();
 $sid = $s->new_stream({ path => '/phase4?what=block403' });
 $frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
+is($frame->{headers}->{':status'}, 403, 'block 403 - phase 4 status');
 ($frame) = grep { $_->{type} eq "DATA" } @$frames;
-is($frame, undef, 'block 403 - phase 4');
-}
+unlike($frame->{data} // '', qr/not found/, 'block 403 - phase 4 body not leaked');
 
 # Nothing to detect
 #like(http_get('/phase1?what=nothing'), qr/phase1\?what=nothing\' not found/, 'nothing phase 1');

--- a/t/coraza-proxy-h2.t
+++ b/t/coraza-proxy-h2.t
@@ -105,7 +105,7 @@ $t->run()->waitforsocket('127.0.0.1:' . port(8081));
 
 ###############################################################################
 
-my ($phase, $s, $sid, $frames, $frame);
+my ($phase, $s, $sid, $frames, $frame, $data);
 
 $s = Test::Nginx::HTTP2->new();
 $sid = $s->new_stream({ path => '/' });
@@ -140,8 +140,9 @@ $sid = $s->new_stream({ path => '/phase4?what=redirect302' });
 $frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 302, 'redirect 302 - phase 4 status');
-($frame) = grep { $_->{type} eq "DATA" } @$frames;
-unlike($frame->{data} // '', qr/not found/, 'redirect 302 - phase 4 body not leaked');
+$data = join '', map { $_->{data} // '' }
+	grep { $_->{type} eq "DATA" } @$frames;
+unlike($data, qr/not found/, 'redirect 302 - phase 4 body not leaked');
 
 # Redirect (301)
 
@@ -158,8 +159,9 @@ $sid = $s->new_stream({ path => '/phase4?what=redirect301' });
 $frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 301, 'redirect 301 - phase 4 status');
-($frame) = grep { $_->{type} eq "DATA" } @$frames;
-unlike($frame->{data} // '', qr/not found/, 'redirect 301 - phase 4 body not leaked');
+$data = join '', map { $_->{data} // '' }
+	grep { $_->{type} eq "DATA" } @$frames;
+unlike($data, qr/not found/, 'redirect 301 - phase 4 body not leaked');
 
 # Block (401)
 
@@ -176,8 +178,9 @@ $sid = $s->new_stream({ path => '/phase4?what=block401' });
 $frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 401, 'block 401 - phase 4 status');
-($frame) = grep { $_->{type} eq "DATA" } @$frames;
-unlike($frame->{data} // '', qr/not found/, 'block 401 - phase 4 body not leaked');
+$data = join '', map { $_->{data} // '' }
+	grep { $_->{type} eq "DATA" } @$frames;
+unlike($data, qr/not found/, 'block 401 - phase 4 body not leaked');
 
 
 # Block (403)
@@ -195,8 +198,9 @@ $sid = $s->new_stream({ path => '/phase4?what=block403' });
 $frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 403, 'block 403 - phase 4 status');
-($frame) = grep { $_->{type} eq "DATA" } @$frames;
-unlike($frame->{data} // '', qr/not found/, 'block 403 - phase 4 body not leaked');
+$data = join '', map { $_->{data} // '' }
+	grep { $_->{type} eq "DATA" } @$frames;
+unlike($data, qr/not found/, 'block 403 - phase 4 body not leaked');
 
 # Nothing to detect
 #like(http_get('/phase1?what=nothing'), qr/phase1\?what=nothing\' not found/, 'nothing phase 1');


### PR DESCRIPTION
The four phase-4 assertions in `t/coraza-h2.t` and `t/coraza-proxy-h2.t` were gated behind `$ENV{TEST_NGINX_UNSAFE}`, which nothing in CI sets, so response-body blocking over HTTP/2 has never actually been exercised there.

The eight `SKIP` blocks (four per file) are un-gated, and each `is($frame, undef, ...)` is replaced with a positive pair: the expected `:status` on the HEADERS frame, plus an `unlike()` proving the blocked upstream body text never appears in a DATA frame. Absence of a DATA frame also follows from a reset connection, a GOAWAY, a timeout or an empty 200, so the old assertion could not tell a correct block from a broken response; `:status` plus a body-leak check can. Plans bumped to match: 20 → 24 and 23 → 27.

The proxy-h2 "nothing to detect" negative control already ran through the `HTTP2`-based loop at the end of `t/coraza-proxy-h2.t`; only its superseded `http_get()` predecessor is commented out, so nothing needed restoring there.

## README

`coraza_delay_response_headers` gets its own directive section — syntax, context (`http`, `server`, `location`), default (`on`), and what turning it off costs: a late phase-4 intervention can no longer replace a response whose headers have already gone out. The directive count goes from four to five.

A short source-build note: `./configure` needs `--with-cc-opt="-Wno-unused-function"` because the installed `coraza/coraza.h` carries libcoraza 1.7.0's cgo preamble, whose `static` callback shims are unused in any given translation unit, and nginx builds with `-Werror`. The Debian package build sets its own CFLAGS and does not need it.

## Testing

Built with `--with-http_v2_module` against nginx 1.31.4 and libcoraza 1.7. Both changed files pass with their new assertions live (24 and 27). Full suite: 477 tests, one failure in `t/coraza-h2-forbidden-headers.t` ("h2: no synthetic Connection" gets no response at all) that I could not attribute to this change — it is untouched here, the module source on this branch is identical to `main`, and upstream's build-test workflow is green on `57ac5da` with the same pins, so I am treating it as local to my h2 build rather than hiding it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added source-build guidance for avoiding compiler warnings treated as errors.
  - Documented the `coraza_delay_response_headers` directive and updated the directive count.

- **Tests**
  - Expanded HTTP/2 coverage for redirect and blocking responses.
  - These scenarios now run consistently and verify both response status codes and that blocked content is not returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->