### PR TITLE
test: cover hostile HTTP framing and persistent-upstream interim statuses

### DIFF
--- a/t/coraza-hostile-framing-differential.t
+++ b/t/coraza-hostile-framing-differential.t
@@ -1,0 +1,375 @@
+#!/usr/bin/perl
+
+# Differential corpus for hostile HTTP framing: conflicting Content-Length /
+# Transfer-Encoding, malformed and truncated chunked bodies, trailers, a
+# Content-Length longer than the transmitted body, and stacked/unknown
+# Content-Encoding under
+# SecResponseBodyAccess On.
+#
+# Only t/coraza-request-body-chunked.t exercises chunking today, and only
+# well-formed chunked bodies; "trailer" appears only in
+# t/coraza-bulk-headers.t as a header name, never as a framing case.  No
+# existing test compares Coraza on against Coraza off for the same hostile
+# input.
+#
+# The point of this file is the PAIRED comparison, not an absolute status
+# code check on the coraza-on config alone.  Every case is sent to a
+# coraza-on location and a coraza-off location that otherwise share the same
+# proxy_pass target, and both responses are inspected for two invariants:
+#
+#   1. Input nginx core itself rejects at the framing layer must never reach
+#      the origin, on OR off.  The origin marks every response it produces
+#      with an ORIGIN-HIT body so "did this reach the origin" is directly
+#      observable in the reply, not inferred from a status code alone.
+#   2. Coraza on must not be WEAKER than Coraza off: whatever core (or
+#      Coraza) does when the request is off must not become a clean
+#      pass-through when Coraza is turned on for the same bytes.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use IO::Socket::INET;
+use Test::More;
+
+use constant CRLF => "\x0d\x0a";
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http proxy/);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        # coraza on: SecRuleEngine On with a body rule, so a request that
+        # frames cleanly and carries no marker sails through, but the
+        # location is still a real WAF, not a pass-through shim.
+        location /on {
+            coraza on;
+            coraza_rules '
+                SecRuleEngine On
+                SecRequestBodyAccess On
+                SecResponseBodyAccess On
+                SecAction "id:7300,phase:1,pass,nolog,t:none,ctl:requestBodyProcessor=URLENCODED"
+                SecRule REQUEST_BODY "@contains BADBODY" "id:7301,phase:2,deny,log,status:403,t:none"
+            ';
+            rewrite ^/on(/.*)$ $1 break;
+            proxy_pass http://127.0.0.1:%%PORT_8081%%;
+        }
+
+        location /off {
+            coraza off;
+            rewrite ^/off(/.*)$ $1 break;
+            proxy_pass http://127.0.0.1:%%PORT_8081%%;
+        }
+    }
+
+    server {
+        listen       127.0.0.1:%%PORT_8081%%;
+        server_name  localhost;
+        access_log   %%TESTDIR%%/origin.log;
+
+        # Every reply from the real origin carries this marker so a test can
+        # tell "the origin answered" from "nginx or Coraza answered instead"
+        # by inspecting the body, independent of the status line.
+        location / {
+            return 200 "ORIGIN-HIT\n";
+        }
+
+        # Stacked / unknown Content-Encoding, for the SecResponseBodyAccess On
+        # response-side cases below.
+        location /stacked {
+            add_header Content-Encoding "gzip, br";
+            return 200 "ORIGIN-HIT-ENCODED\n";
+        }
+
+        location /unknown {
+            add_header Content-Encoding "x-unknown-encoding";
+            return 200 "ORIGIN-HIT-ENCODED\n";
+        }
+    }
+}
+
+EOF
+
+$t->try_run('no coraza');
+$t->plan(51);
+our $origin_log = $t->testdir() . '/origin.log';
+
+###############################################################################
+
+# --- helpers ----------------------------------------------------------------
+
+# Send raw bytes and read whatever comes back, with a bounded timeout; never
+# use http_get/http(), which build well-formed request lines and would
+# normalize away the very malformations under test.
+sub raw {
+	my ($bytes, %opt) = @_;
+
+	my $s = IO::Socket::INET->new(
+		Proto    => 'tcp',
+		PeerAddr => '127.0.0.1:' . port(8080),
+	) or die "Can't connect: $!\n";
+	$s->autoflush(1);
+
+	local $SIG{ALRM} = sub { die "timeout\n" };
+	my $reply = '';
+	eval {
+		alarm(5);
+		$s->print($bytes) or die "Can't write request: $!\n";
+		if ($opt{half_close}) {
+			shutdown($s, 1)
+				or die "Can't half-close request stream: $!\n";
+		}
+		my $buf;
+		while (1) {
+			my $n = sysread($s, $buf, 65536);
+			die "Can't read response: $!\n" unless defined $n;
+			last if $n == 0;
+			$reply .= $buf;
+		}
+		alarm(0);
+	};
+	my $err = $@;
+	alarm(0);
+	$s->close();
+	die $err if $err;
+	return $reply;
+}
+
+sub status_of {
+	my ($reply) = @_;
+	return 'NONE' unless defined $reply and length $reply;
+	return $1 if $reply =~ m!^HTTP/1\.[01]\s+(\d\d\d)!;
+	return 'MALFORMED';
+}
+
+sub reached_origin {
+	my ($reply) = @_;
+	return defined $reply && $reply =~ /ORIGIN-HIT/;
+}
+
+sub origin_requests {
+	return 0 unless -f $origin_log;
+	open my $log, '<', $origin_log
+		or die "Can't read $origin_log: $!\n";
+	my $count = 0;
+	$count++ while <$log>;
+	close $log or die "Can't close $origin_log: $!\n";
+	return $count;
+}
+
+# Run one malformed case against both /on and /off. Nginx core must refuse it
+# before proxying, with Coraza on or off.
+sub differential {
+	my ($name, $request, %opt) = @_;
+
+	my $before = origin_requests();
+	my $on = raw($request =~ s!^(\S+ )/!${1}/on!mr,
+		half_close => $opt{half_close});
+	my $after_on = origin_requests();
+	my $off = raw($request =~ s!^(\S+ )/!${1}/off!mr,
+		half_close => $opt{half_close});
+	my $after_off = origin_requests();
+
+	my $on_status  = status_of($on);
+	my $off_status = status_of($off);
+
+	ok($off_status !~ /^2/,
+		"$name: core rejects malformed framing (coraza off: $off_status)");
+	ok($on_status !~ /^2/,
+		"$name: coraza-on is not weaker than coraza-off ($on_status)");
+	is($after_on, $before,
+		"$name: malformed request never reaches origin (coraza on)");
+	is($after_off, $after_on,
+		"$name: malformed request never reaches origin (coraza off)");
+
+}
+
+###############################################################################
+# --- conflicting framing: Content-Length vs Transfer-Encoding --------------
+
+# RFC 9112 6.1: a message with both headers is invalid and must be rejected
+# or the Transfer-Encoding header stripped and the message treated as
+# malformed -- either way the origin must never see it as a valid request.
+differential('conflicting Content-Length and Transfer-Encoding headers',
+	"POST / HTTP/1.1" . CRLF
+	. "Host: localhost" . CRLF
+	. "Content-Length: 5" . CRLF
+	. "Transfer-Encoding: chunked" . CRLF
+	. "Connection: close" . CRLF . CRLF
+	. "3" . CRLF . "abc" . CRLF . "0" . CRLF . CRLF);
+
+# --- malformed / truncated chunked bodies -----------------------------------
+
+# Non-hex chunk size.
+differential('non-hex chunk size',
+	"POST / HTTP/1.1" . CRLF
+	. "Host: localhost" . CRLF
+	. "Transfer-Encoding: chunked" . CRLF
+	. "Connection: close" . CRLF . CRLF
+	. "zzzz" . CRLF . "abcd" . CRLF . "0" . CRLF . CRLF);
+
+# Missing terminating CRLF after the chunk data.
+differential('missing chunk terminator',
+	"POST / HTTP/1.1" . CRLF
+	. "Host: localhost" . CRLF
+	. "Transfer-Encoding: chunked" . CRLF
+	. "Connection: close" . CRLF . CRLF
+	. "3" . CRLF . "abcXXXX" . CRLF . "0" . CRLF . CRLF);
+
+# Negative-looking (signed) chunk size.
+differential('negative chunk size',
+	"POST / HTTP/1.1" . CRLF
+	. "Host: localhost" . CRLF
+	. "Transfer-Encoding: chunked" . CRLF
+	. "Connection: close" . CRLF . CRLF
+	. "-3" . CRLF . "abc" . CRLF . "0" . CRLF . CRLF);
+
+# Absurdly huge chunk size that cannot exist on the wire; the connection must
+# be refused/truncated rather than nginx blocking waiting for it, and the
+# origin must not see it.
+differential('huge chunk size',
+	"POST / HTTP/1.1" . CRLF
+	. "Host: localhost" . CRLF
+	. "Transfer-Encoding: chunked" . CRLF
+	. "Connection: close" . CRLF . CRLF
+	. "FFFFFFFFFFFFFFFF" . CRLF . "abc" . CRLF . "0" . CRLF . CRLF);
+
+# Truncated body: declares a chunk but the connection is closed before the
+# chunk data or the final "0" chunk ever arrives.
+differential('truncated chunked body',
+	"POST / HTTP/1.1" . CRLF
+	. "Host: localhost" . CRLF
+	. "Transfer-Encoding: chunked" . CRLF
+	. "Connection: close" . CRLF . CRLF
+	. "a" . CRLF . "abc",
+	half_close => 1);
+
+# --- trailers ---------------------------------------------------------------
+
+# A well-formed trailer section is legal chunked framing (RFC 9112 7.1.2);
+# this is the well-formed control showing legitimate trailers are not
+# themselves treated as malformed by either config.
+{
+	my $body = "3" . CRLF . "abc" . CRLF . "0" . CRLF
+		. "X-Trailer: legit" . CRLF . CRLF;
+	my $req = "POST / HTTP/1.1" . CRLF
+		. "Host: localhost" . CRLF
+		. "Transfer-Encoding: chunked" . CRLF
+		. "Connection: close" . CRLF . CRLF
+		. $body;
+
+	my $on  = raw($req =~ s!^(\S+ )/!${1}/on!mr);
+	my $off = raw($req =~ s!^(\S+ )/!${1}/off!mr);
+
+	is(status_of($on), '200',
+		'well-formed trailer: coraza-on passes clean chunked body');
+	is(status_of($off), '200',
+		'well-formed trailer: coraza-off passes clean chunked body');
+}
+
+# --- Content-Length vs actual body length mismatch --------------------------
+
+# Declares more bytes than are ever sent, then closes -- must not block
+# waiting forever nor forward a short body as if it were complete.
+differential('Content-Length longer than actual body',
+	"POST / HTTP/1.1" . CRLF
+	. "Host: localhost" . CRLF
+	. "Content-Length: 100" . CRLF
+	. "Connection: close" . CRLF . CRLF
+	. "short",
+	half_close => 1);
+
+###############################################################################
+# --- negative control: benign well-formed request reaches the origin ------
+
+{
+	my $on  = raw("GET /on HTTP/1.1" . CRLF . "Host: localhost" . CRLF
+		. "Connection: close" . CRLF . CRLF);
+	my $off = raw("GET /off HTTP/1.1" . CRLF . "Host: localhost" . CRLF
+		. "Connection: close" . CRLF . CRLF);
+
+	like($on, qr/^HTTP\/1\.1 200/, 'control: benign request passes coraza-on');
+	ok(reached_origin($on), 'control: benign request reaches origin (coraza on)');
+	like($off, qr/^HTTP\/1\.1 200/, 'control: benign request passes coraza-off');
+	ok(reached_origin($off), 'control: benign request reaches origin (coraza off)');
+}
+
+# --- Coraza's own rule still fires on well-formed input --------------------
+#
+# The differential cases above are all about FRAMING invariants that nginx
+# core enforces regardless of Coraza.  This case is the complement: proof
+# that Coraza's own SecRule ("id:7301", REQUEST_BODY contains BADBODY) still
+# blocks a well-formed request on /on while /off lets the identical bytes
+# through to the origin -- so a differential run that (incorrectly) always
+# treated "on" and "off" as equally strict would still be caught here.
+{
+	my $body = 'field=BADBODY';
+	my $req = "POST / HTTP/1.1" . CRLF
+		. "Host: localhost" . CRLF
+		. "Content-Length: " . length($body) . CRLF
+		. "Connection: close" . CRLF . CRLF
+		. $body;
+
+	my $on  = raw($req =~ s!^(\S+ )/!${1}/on!mr);
+	my $off = raw($req =~ s!^(\S+ )/!${1}/off!mr);
+
+	like($on, qr/^HTTP\/1\.1 403/,
+		"Coraza's own rule blocks a well-formed BADBODY request (coraza on)");
+	ok(!reached_origin($on),
+		"Coraza's own rule keeps a blocked BADBODY request from the origin (coraza on)");
+	like($off, qr/^HTTP\/1\.1 200/,
+		'well-formed BADBODY request passes through when coraza is off (control)');
+	ok(reached_origin($off),
+		'well-formed BADBODY request reaches origin when coraza is off (control)');
+}
+
+###############################################################################
+# --- stacked / unknown Content-Encoding under SecResponseBodyAccess On -----
+#
+# These exercise the response side: the origin sends back a body under a
+# Content-Encoding Coraza cannot necessarily decode, with
+# SecResponseBodyAccess On already set in the /on location.  Coraza must not
+# crash or corrupt the passthrough; nginx core still owns whether the encoded
+# bytes are forwarded unchanged.
+
+for my $path (qw(/on/stacked /off/stacked /on/unknown /off/unknown)) {
+	my $r = http_get($path);
+	my $encoding = $path =~ /stacked/ ? 'gzip, br' : 'x-unknown-encoding';
+	like($r, qr/^HTTP\/1\.[01] 200/,
+		"stacked/unknown Content-Encoding: $path does not crash the proxy");
+	like($r, qr/^Content-Encoding: \Q$encoding\E\r?$/mi,
+		"stacked/unknown Content-Encoding: $path preserves the header");
+	like($r, qr/\r\n\r\nORIGIN-HIT-ENCODED\n\z/,
+		"stacked/unknown Content-Encoding: $path preserves the body");
+}
+
+$t->stop();
+
+unlike($t->read_file('error.log'), qr/signal 11|SIGSEGV|AddressSanitizer/,
+	'no crash handling hostile HTTP framing, trailers, or stacked Content-Encoding');
+
+###############################################################################

--- a/t/coraza-hostile-request-framing.t
+++ b/t/coraza-hostile-request-framing.t
@@ -1,0 +1,354 @@
+#!/usr/bin/perl
+
+# Tests for Coraza-nginx connector (hostile request framing, on/off
+# differential).
+#
+# nginx's core HTTP parser is the first line of defense against request
+# smuggling and framing attacks: conflicting Content-Length/Transfer-Encoding,
+# malformed chunk sizes, trailing garbage after the terminal chunk, and a body
+# that does not match its declared Content-Length. The connector must never
+# make nginx's own verdict on these WORSE -- a request core nginx rejects must
+# never reach the proxied origin, whether coraza is on or off, and turning
+# coraza on must not relax a rejection into a pass.
+#
+# Design: an origin daemon marks every request it actually receives by
+# writing a line to a marker file per case. Each hostile case is sent to a
+# pair of locations that are identical except for `coraza on|off`. The oracle
+# is (a) the response is never the origin's 200 OK-off-limits marker leaking
+# through as a successful smuggled request, and (b) the origin is not invoked
+# at all for input nginx's own parser rejects -- checked identically for both
+# locations. Where nginx's parser accepts and forwards the request (case is
+# framing-ambiguous but not core-rejected), coraza on must reject at least as
+# often as coraza off; it must never be the on-side that lets through what the
+# off-side blocked.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+use IO::Socket::INET;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+use constant CRLF => "\x0d\x0a";
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(34);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:%%PORT_8080%%;
+        server_name  localhost;
+
+        location /off/ {
+            coraza off;
+            proxy_pass http://127.0.0.1:%%PORT_8081%%/;
+        }
+
+        location /on/ {
+            coraza on;
+            coraza_rules '
+                SecRuleEngine On
+                SecRequestBodyAccess On
+                SecResponseBodyAccess On
+                SecAction "id:7300,phase:1,pass,nolog,t:none,ctl:requestBodyProcessor=URLENCODED"
+                SecRule RESPONSE_BODY "@contains BADBODY" "id:7301,phase:4,t:none,deny,log,status:403"
+            ';
+            proxy_pass http://127.0.0.1:%%PORT_8081%%/;
+        }
+    }
+}
+EOF
+
+# Captured as a plain string, not the $t object itself, and BEFORE the daemon
+# is forked: a named sub closing over $t keeps its refcount alive until
+# global destruction, which shifts Test::Nginx's DESTROY-time "no
+# alerts"/"no sanitizer errors" checks past Test::Builder's own end-of-run
+# plan verification and produces a spurious "planned N tests but ran N-2"
+# diagnostic with a nonzero exit despite every subtest passing. The forked
+# daemon also needs the plain string, since it must be set before fork().
+my $testdir = $t->testdir();
+
+$t->run_daemon(\&origin_daemon);
+$t->run()->waitforsocket('127.0.0.1:' . port(8081));
+$t->todo_alerts();
+
+###############################################################################
+
+# --- case 1: conflicting Content-Length vs Transfer-Encoding --------------
+#
+# Smuggling-classic: two framing headers that disagree on where the body
+# ends. nginx's core must reject this outright (400) for both on and off --
+# it must never reach the origin under either.
+
+for my $loc (qw(off on)) {
+	my $r = raw_request(
+		"POST /$loc/clte HTTP/1.1" . CRLF
+		. "Host: localhost" . CRLF
+		. "Content-Length: 5" . CRLF
+		. "Transfer-Encoding: chunked" . CRLF
+		. "Connection: close" . CRLF . CRLF
+		. "3" . CRLF . "abc" . CRLF . "0" . CRLF . CRLF
+	);
+	like($r, qr!^HTTP/1\.1 400!,
+		"conflicting Content-Length/Transfer-Encoding rejected by core ($loc)");
+}
+
+# --- case 2: malformed / truncated chunk size ------------------------------
+
+for my $loc (qw(off on)) {
+	my $r = raw_request(
+		"POST /$loc/badchunk HTTP/1.1" . CRLF
+		. "Host: localhost" . CRLF
+		. "Transfer-Encoding: chunked" . CRLF
+		. "Connection: close" . CRLF . CRLF
+		. "ZZZ" . CRLF . "abc" . CRLF . "0" . CRLF . CRLF
+	);
+	unlike($r, qr!^HTTP/1\.1 200!,
+		"malformed chunk size never yields 200 ($loc)");
+}
+
+# --- case 3: chunk trailers and surplus bytes after the final chunk -------
+#
+# Well-formed terminal chunk plus a trailer section, followed by extra bytes
+# shaped like a second request. The request itself is legitimate (RFC 9112
+# allows trailers), so it MUST be served and reach the origin exactly like a
+# plain request -- a connector that rejected the whole request would pass a
+# check that only looks for the absence of the surplus. The surplus bytes
+# must never be routed as a request of their own: the request carries
+# `Connection: close`, so nginx must discard anything after the terminal
+# chunk and trailers instead of pipelining it, and the origin must never see
+# `/smuggled`.
+
+for my $loc (qw(off on)) {
+	my $r = raw_request(
+		"POST /$loc/trailer HTTP/1.1" . CRLF
+		. "Host: localhost" . CRLF
+		. "Transfer-Encoding: chunked" . CRLF
+		. "Connection: close" . CRLF . CRLF
+		. "3" . CRLF . "abc" . CRLF . "0" . CRLF
+		. "X-Trailer: yes" . CRLF . CRLF
+		. "GET /$loc/smuggled HTTP/1.1" . CRLF . "Host: localhost" . CRLF . CRLF
+	);
+	like($r, qr!^HTTP/1\.1 200!,
+		"legitimate chunked request with a trailer section is served ($loc)");
+	is(scalar(() = $r =~ m!^HTTP/1\.1 !mg), 1,
+		"exactly one response: surplus bytes after the final chunk are not pipelined ($loc)");
+}
+
+# --- case 4: Content-Length vs actual body length mismatch ----------------
+#
+# Declared length longer than the bytes actually sent before the peer closes:
+# nginx must not proxy a short/truncated body as if it were complete, and
+# must not hang past the read timeout in a way that yields a 200.
+
+for my $loc (qw(off on)) {
+	my $r = short_body_request($loc);
+	unlike($r, qr!^HTTP/1\.1 200!,
+		"Content-Length longer than actual body never yields 200 ($loc)");
+}
+
+# --- case 5: stacked/unknown Content-Encoding under response body access --
+#
+# The /on/ location above already runs with SecResponseBodyAccess On, so it
+# is reused directly here -- no second config/reload needed. Neither nginx
+# nor the connector decodes response content codings, so an origin response
+# advertising a chain nginx/coraza cannot decode (gzip+br stacked, or an
+# unknown token) is passed through as opaque bytes. A 200 alone would not
+# prove that: a regression that stripped the Content-Encoding header or
+# rewrote the body would still return one. Each case therefore also asserts
+# that the header arrives with its exact value and that the payload arrives
+# byte for byte.
+
+for my $enc ('gzip,br', 'unknown-codec', 'identity,gzip,unknown') {
+	for my $loc (qw(off on)) {
+		my $r = stacked_encoding_request($loc, $enc);
+		like($r, qr!^HTTP/1\.1 200!,
+			"stacked/unknown Content-Encoding '$enc' passes through undecoded, no hang ($loc)");
+		like($r, qr!\r\nContent-Encoding:\s*\Q$enc\E\r\n!i,
+			"Content-Encoding '$enc' reaches the client unchanged ($loc)");
+		like($r, qr!\r\n\r\npayload\z!,
+			"the opaque encoded payload reaches the client unchanged ($loc)");
+	}
+}
+
+$t->stop();
+
+is(origin_saw('clte'), 0,
+	'origin never invoked for the Content-Length vs Transfer-Encoding conflict (core rejects before proxy_pass)');
+is(origin_saw('badchunk'), 0,
+	'origin never invoked for a malformed chunk size');
+is(origin_saw('trailer'), 1,
+	'origin received the legitimate trailer-carrying request (the reject '
+	. 'of the surplus did not also reject the request in front of it)');
+is(origin_saw('smuggled'), 0,
+	'origin never invoked via bytes smuggled past the terminal chunk');
+is(origin_saw('short'), 0,
+	'origin never invoked for the truncated body (nginx does not proxy a '
+	. 'request whose declared Content-Length was never fully received)');
+
+unlike($t->read_file('error.log'), qr/signal 11|SIGSEGV|AddressSanitizer/,
+	'no crash handling hostile request framing');
+
+###############################################################################
+
+sub raw_request {
+	my ($request) = @_;
+
+	my $s = IO::Socket::INET->new(
+		Proto => 'tcp',
+		PeerAddr => '127.0.0.1:' . port(8080),
+	) or die "Can't connect to nginx: $!\n";
+	$s->autoflush(1);
+
+	print $s $request;
+
+	my $reply = '';
+	local $SIG{ALRM} = sub { die "timeout\n" };
+	eval {
+		alarm(5);
+		local $/;
+		$reply = <$s> // '';
+		alarm(0);
+	};
+	# A SIGALRM stores "timeout\n" in $@ via die; swallowing it would let
+	# raw_request return '' silently, and every unlike(..., qr!^HTTP/1\.1
+	# 200!) below would then pass vacuously on a hung connection instead of
+	# on an observed rejection. Cancel any pending alarm and rethrow so a
+	# real hang fails the test loudly instead of faking a pass.
+	if (my $err = $@) {
+		alarm(0);
+		close $s;
+		die $err;
+	}
+	close $s;
+	return $reply;
+}
+
+# Send a Content-Length declaring more bytes than are actually written, then
+# half-close the write side and close -- the classic truncated-body case.
+# Half-closing (not just close()) is what actually signals "no more bytes
+# coming" to nginx while the read side stays open long enough to receive a
+# reply; a plain close() can leave nginx seeing a live, merely slow request
+# instead of the peer-closed truncation this case is meant to exercise.
+sub short_body_request {
+	my ($loc) = @_;
+
+	my $s = IO::Socket::INET->new(
+		Proto => 'tcp',
+		PeerAddr => '127.0.0.1:' . port(8080),
+	) or die "Can't connect to nginx: $!\n";
+	$s->autoflush(1);
+
+	print $s "POST /$loc/short HTTP/1.1" . CRLF
+		. "Host: localhost" . CRLF
+		. "Content-Length: 100" . CRLF
+		. "Connection: close" . CRLF . CRLF
+		. "short";
+	shutdown($s, 1) or die "Can't half-close request socket: $!\n";
+
+	my $reply = '';
+	local $SIG{ALRM} = sub { die "timeout\n" };
+	eval {
+		alarm(3);
+		local $/;
+		$reply = <$s> // '';
+		alarm(0);
+	};
+	if (my $err = $@) {
+		alarm(0);
+		close $s;
+		die $err;
+	}
+	close $s;
+	return $reply;
+}
+
+sub stacked_encoding_request {
+	my ($loc, $enc) = @_;
+
+	return raw_request(
+		"GET /$loc/enc/$enc HTTP/1.1" . CRLF
+		. "Host: localhost" . CRLF
+		. "Connection: close" . CRLF . CRLF
+	);
+}
+
+# --- origin daemon: records which URIs it actually received ---------------
+
+sub origin_saw {
+	my ($tag) = @_;
+	my $file = $testdir . "/seen-$tag";
+	return -f $file ? 1 : 0;
+}
+
+sub origin_daemon {
+	my $server = IO::Socket::INET->new(
+		Proto => 'tcp',
+		LocalHost => '127.0.0.1:' . port(8081),
+		Listen => 5,
+		Reuse => 1
+	) or die "Can't create listening socket: $!\n";
+
+	local $SIG{PIPE} = 'IGNORE';
+
+	while (my $client = $server->accept()) {
+		$client->autoflush(1);
+
+		my $headers = '';
+		while (<$client>) {
+			$headers .= $_;
+			last if (/^\x0d?\x0a?$/);
+		}
+
+		my ($uri) = $headers =~ /^\S+\s+(\S+)/;
+		$uri //= '';
+
+		for my $tag (qw(clte badchunk smuggled short trailer)) {
+			if ($uri =~ /\Q$tag\E/) {
+				open(my $fh, '>', $testdir . "/seen-$tag");
+				close($fh);
+			}
+		}
+
+		if ($uri =~ m{/enc/([^/\s]+)}) {
+			my $enc = $1;
+			my $body = "payload";
+			print $client "HTTP/1.1 200 OK\r\n"
+				. "Content-Encoding: $enc\r\n"
+				. "Content-Length: " . length($body) . "\r\n"
+				. "Connection: close\r\n\r\n"
+				. $body;
+		} else {
+			my $body = "TEST-OK\n";
+			print $client "HTTP/1.1 200 OK\r\n"
+				. "Content-Length: " . length($body) . "\r\n"
+				. "Connection: close\r\n\r\n"
+				. $body;
+		}
+
+		close $client;
+	}
+}
+
+###############################################################################

--- a/t/coraza-persistent-upstream-interim.t
+++ b/t/coraza-persistent-upstream-interim.t
@@ -167,10 +167,6 @@ close $s;
 
 $t->stop();
 
-is(origin_saw('unexpected'), 0,
-	'origin never received a request URI other than the five sent '
-	. '(rules out request-side desync from the misleading responses)');
-
 # Every request-bearing accepted connection logs its (monotonically
 # assigned) connection id next to each URI it served, in
 # <testdir>/conn-log. The earlier response-content assertions do not, by
@@ -184,11 +180,17 @@ is(origin_saw('unexpected'), 0,
 # papered over with a reuse claim that is not true.
 my @conn_log = split /\n/, $t->read_file('conn-log');
 my %conn_for_uri;
+my @origin_uris;
 for my $line (@conn_log) {
 	my ($id, $uri) = split /\s+/, $line, 2;
 	next unless defined $uri;
+	push @origin_uris, $uri;
 	$conn_for_uri{$uri} = $id unless exists $conn_for_uri{$uri};
 }
+
+is_deeply(\@origin_uris, [qw(
+	/early-hints /no-content /not-modified /no-content-chunked /plain
+)], 'origin received exactly the five request URIs in order');
 
 is($conn_for_uri{'/no-content'} // 'missing:/no-content',
 	$conn_for_uri{'/early-hints'} // 'missing:/early-hints',

--- a/t/coraza-persistent-upstream-interim.t
+++ b/t/coraza-persistent-upstream-interim.t
@@ -1,0 +1,377 @@
+#!/usr/bin/perl
+
+# Tests for Coraza-nginx connector (persistent upstream, interim/no-body
+# statuses, misleading framing).
+#
+# With `keepalive` on the upstream block nginx reuses ONE TCP connection to
+# the origin across requests, for as long as nginx's own upstream code
+# considers that connection trustworthy. Three status classes never carry a
+# body the connector's phase-4 body filter can wait on:
+#
+#   * 103 Early Hints followed by the real final response on the SAME
+#     connection -- the connector must not treat the 103 as the final
+#     header set and must not stall waiting for a body that belongs to the
+#     103.
+#   * 204 No Content -- must never carry a body per RFC 9110 regardless of
+#     what Content-Length/Transfer-Encoding the origin (misleadingly) sends.
+#   * 304 Not Modified -- same body-less contract, tested with the same
+#     misleading framing.
+#
+# Each is sent with a Content-Length that lies about a body actually being
+# present, and the 204 is additionally sent with `Transfer-Encoding: chunked`
+# framing a chunked body, so both framing forms the origin could lie with
+# are covered. Verified against this worktree's build (nginx 1.31.3): the
+# well-formed 103-then-final handoff genuinely reuses the SAME upstream
+# connection (proven via a per-connection id the origin logs alongside
+# every URI it serves -- see conn-log below), matching the design intent
+# above. For /no-content and /not-modified, nginx's own upstream layer logs
+# "upstream sent more data than specified in Content-Length" and CLOSES
+# that connection rather than risk misreading the surplus bytes as the
+# start of the next response -- it does NOT keep reusing a connection it
+# has just observed lying about its own framing. That closed-not-reused
+# outcome, not blanket reuse, IS the anti-contamination guarantee for a
+# connection an origin has shown to misreport Content-Length: nginx trades
+# the (now-tainted) connection for provable safety instead of gambling on
+# resynchronizing it. The oracle: no delayed-header stall (bounded read
+# completes within the alarm), the body-less contract holds regardless of
+# which connection serves the response, and the request that follows --
+# on whichever connection nginx chooses -- is the correct, uncontaminated
+# one, never bytes leaked from an earlier case.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+use IO::Socket::INET;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+use constant CRLF => "\x0d\x0a";
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(17);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    upstream backend {
+        server 127.0.0.1:%%PORT_8081%%;
+        keepalive 4;
+    }
+
+    server {
+        listen       127.0.0.1:%%PORT_8080%%;
+        server_name  localhost;
+
+        location / {
+            coraza on;
+            coraza_rules '
+                SecRuleEngine On
+                SecResponseBodyAccess On
+                SecRule RESPONSE_BODY "@contains BADBODY" "id:7400,phase:4,t:none,deny,log,status:403"
+            ';
+            proxy_pass http://backend;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+        }
+    }
+}
+EOF
+
+# Captured as a plain string before the daemon forks: a named sub closing
+# over $t (rather than a plain string) keeps $t's refcount alive until
+# global destruction, which shifts Test::Nginx's DESTROY-time "no
+# alerts"/"no sanitizer errors" checks past Test::Builder's own end-of-run
+# plan verification and produces a spurious "planned N tests but ran N-2"
+# diagnostic with a nonzero exit despite every subtest passing.
+my $testdir = $t->testdir();
+
+$t->run_daemon(\&origin_daemon);
+$t->run()->waitforsocket('127.0.0.1:' . port(8081));
+$t->todo_alerts();
+
+###############################################################################
+
+# One client connection to nginx, kept open across all three cases plus a
+# trailing control request -- proves neither a stalled header delay nor
+# leftover bytes from a body-less status corrupt the NEXT response read off
+# the same connection.
+
+my $s = IO::Socket::INET->new(
+	Proto => 'tcp',
+	PeerAddr => '127.0.0.1:' . port(8080),
+) or die "Can't connect to nginx: $!\n";
+$s->autoflush(1);
+
+# --- case 1: 103 Early Hints then the final response ----------------------
+
+my $r103 = client_request($s, '/early-hints');
+unlike($r103, qr/^$/, '103-then-final: response received without a delayed-header stall');
+like($r103, qr!^HTTP/1\.1 200!,
+	'103-then-final: client sees the FINAL status, not the interim 103');
+unlike($r103, qr!^HTTP/1\.1 103!m,
+	'103-then-final: the 103 status line itself is not surfaced to the client');
+
+# --- case 2: 204 No Content with misleading framing ------------------------
+
+my $r204 = client_request($s, '/no-content');
+like($r204, qr!^HTTP/1\.1 204!, '204: status line passed through');
+unlike($r204, qr!BADBODY!,
+	'204: no body delivered to the client despite the origin sending one');
+
+# --- case 3: 304 Not Modified with misleading framing -----------------------
+
+my $r304 = client_request($s, '/not-modified');
+like($r304, qr!^HTTP/1\.1 304!, '304: status line passed through');
+unlike($r304, qr!BADBODY!,
+	'304: no body delivered to the client despite the origin sending one');
+
+# --- case 3b: 204 No Content with chunked Transfer-Encoding framing -------
+
+my $r204c = client_request($s, '/no-content-chunked');
+like($r204c, qr!^HTTP/1\.1 204!,
+	'204 (chunked framing): status line passed through');
+unlike($r204c, qr!BADBODY|Transfer-Encoding!i,
+	'204 (chunked framing): neither the chunked body nor the '
+	. 'Transfer-Encoding header reaches the client');
+
+# --- control: the connection is still usable for a plain request afterward -
+
+my $rctrl = client_request($s, '/plain');
+like($rctrl, qr!^HTTP/1\.1 200!,
+	'control: connection still serves a correct response after three '
+	. 'body-less/interim statuses (no contamination, no stall)');
+like($rctrl, qr!PLAIN-OK!,
+	'control: the plain response body is exactly the next response, not '
+	. 'leftover bytes from an earlier case');
+
+close $s;
+
+$t->stop();
+
+is(origin_saw('unexpected'), 0,
+	'origin never received a request URI other than the five sent '
+	. '(rules out request-side desync from the misleading responses)');
+
+# Every request-bearing accepted connection logs its (monotonically
+# assigned) connection id next to each URI it served, in
+# <testdir>/conn-log. The earlier response-content assertions do not, by
+# themselves, prove which connection served which request -- nginx could
+# silently reconnect after any response and every prior assertion would
+# still pass. Verified separately (see header comment): reuse across the
+# 103-then-final handoff is the real, observed behavior for THIS worktree's
+# build, so that is what gets asserted; nginx closing the connection after
+# /no-content or /not-modified (both of which lied about Content-Length) is
+# also real, observed, and correct, so it is asserted as a close, not a gap
+# papered over with a reuse claim that is not true.
+my @conn_log = split /\n/, $t->read_file('conn-log');
+my %conn_for_uri;
+for my $line (@conn_log) {
+	my ($id, $uri) = split /\s+/, $line, 2;
+	next unless defined $uri;
+	$conn_for_uri{$uri} = $id unless exists $conn_for_uri{$uri};
+}
+
+is($conn_for_uri{'/no-content'} // 'missing:/no-content',
+	$conn_for_uri{'/early-hints'} // 'missing:/early-hints',
+	'103-then-final and the immediately following request are served on '
+	. 'the SAME persistent upstream connection (real reuse, not a fresh '
+	. 'connect per request)');
+
+isnt($conn_for_uri{'/not-modified'}, $conn_for_uri{'/no-content'},
+	'nginx closes (does not keep reusing) the connection right after an '
+	. 'origin response that lied about its own Content-Length, rather '
+	. 'than gambling on resynchronizing a connection of provably '
+	. 'untrustworthy framing');
+
+isnt($conn_for_uri{'/no-content-chunked'}, $conn_for_uri{'/not-modified'},
+	'nginx also closes the connection after the misleading 304 (the '
+	. 'request after it lands on a fresh upstream connection)');
+
+isnt($conn_for_uri{'/plain'}, $conn_for_uri{'/no-content-chunked'},
+	'nginx closes the connection after a 204 whose surplus bytes were '
+	. 'chunked-framed, exactly as it does for the Content-Length lie');
+
+unlike($t->read_file('error.log'), qr/signal 11|SIGSEGV|AddressSanitizer/,
+	'no crash handling interim/no-body statuses on a persistent upstream');
+
+###############################################################################
+
+sub client_request {
+	my ($sock, $uri) = @_;
+
+	print $sock "GET $uri HTTP/1.1" . CRLF
+		. "Host: localhost" . CRLF . CRLF;
+
+	my $reply = '';
+	local $SIG{ALRM} = sub { die "timeout\n" };
+	eval {
+		alarm(5);
+		# Read until we have a full status-line + headers block; for the
+		# body-less cases that IS the whole response, for /plain and the
+		# early-hints case we also drain the Content-Length body so the
+		# next read on the connection starts at the next response.
+		while (1) {
+			my $buf;
+			my $n = sysread($sock, $buf, 4096);
+			last unless $n;
+			$reply .= $buf;
+			last if response_complete($reply);
+		}
+		alarm(0);
+	};
+	# Swallowing a SIGALRM timeout here would let client_request return ''
+	# (or a partial buffer) silently on a real stall, and the "no
+	# delayed-header stall" assertion below would then pass on a hang
+	# instead of on an observed response. Cancel any pending alarm and
+	# rethrow so a genuine timeout fails loudly.
+	if (my $err = $@) {
+		alarm(0);
+		die $err;
+	}
+	return $reply;
+}
+
+# Heuristic completion check good enough for this fixture's small, known
+# response shapes: headers terminated, and if a Content-Length is present
+# the body has fully arrived.
+sub response_complete {
+	my ($buf) = @_;
+
+	return 0 unless $buf =~ /\r\n\r\n/;
+
+	my ($head, $rest) = split /\r\n\r\n/, $buf, 2;
+	$rest //= '';
+
+	if ($head =~ /^HTTP\/1\.1 (204|304)/) {
+		return 1;
+	}
+
+	if ($head =~ /Content-Length:\s*(\d+)/i) {
+		return length($rest) >= $1;
+	}
+
+	# No Content-Length and not body-less: treat headers-complete as done
+	# for this fixture (used only by the 103 case, whose final response
+	# below always sets Content-Length).
+	return 1;
+}
+
+sub origin_saw {
+	my ($tag) = @_;
+	my $file = $testdir . "/seen-$tag";
+	return -f $file ? 1 : 0;
+}
+
+# --- origin daemon: persistent connections, five sequential requests ------
+
+sub origin_daemon {
+	my $server = IO::Socket::INET->new(
+		Proto => 'tcp',
+		LocalHost => '127.0.0.1:' . port(8081),
+		Listen => 5,
+		Reuse => 1
+	) or die "Can't create listening socket: $!\n";
+
+	local $SIG{PIPE} = 'IGNORE';
+
+	# Accept connections in a loop, not once: Test::Nginx's own
+	# waitforsocket() readiness probe opens and immediately closes a
+	# connection before the real client ever connects, and nginx itself may
+	# open a fresh upstream connection if it does not keep the first one
+	# alive. A single accept() would consume the probe's connection and
+	# leave the real traffic unserved. Each accepted connection is served
+	# until the peer stops sending requests (EOF), then we accept the next.
+	#
+	# Every accepted connection gets a monotonically increasing id, logged
+	# to <testdir>/conn-log alongside each URI it serves, so the parent can
+	# tell which of the five requests shared a connection: reuse across the
+	# 103-then-final handoff, and a fresh connection after each response
+	# that misreported its own framing.
+	my $conn_id = 0;
+
+	while (my $client = $server->accept()) {
+		$client->autoflush(1);
+		$conn_id++;
+		my $this_conn = $conn_id;
+
+		while (1) {
+			my $headers = '';
+			while (<$client>) {
+				$headers .= $_;
+				last if (/^\x0d?\x0a?$/);
+			}
+
+			last unless length($headers);
+
+			my ($uri) = $headers =~ /^\S+\s+(\S+)/;
+			$uri //= '';
+
+			if (length($uri)) {
+				open(my $fh, '>>', $testdir . "/conn-log");
+				print $fh "$this_conn $uri\n";
+				close($fh);
+			}
+
+			if ($uri eq '/early-hints') {
+				# Interim 103 first, no body, then the real final response
+				# -- both on the same connection, back to back.
+				print $client "HTTP/1.1 103 Early Hints\r\n"
+					. "Link: </style.css>; rel=preload\r\n\r\n";
+				print $client "HTTP/1.1 200 OK\r\n"
+					. "Content-Length: 7\r\n\r\n"
+					. "EH-DONE";
+			} elsif ($uri eq '/no-content') {
+				# 204 must never carry a body; send misleading framing
+				# headers plus a body anyway to prove nginx/coraza strip it
+				# regardless.
+				print $client "HTTP/1.1 204 No Content\r\n"
+					. "Content-Length: 7\r\n\r\n"
+					. "BADBODY";
+			} elsif ($uri eq '/not-modified') {
+				print $client "HTTP/1.1 304 Not Modified\r\n"
+					. "Content-Length: 7\r\n\r\n"
+					. "BADBODY";
+			} elsif ($uri eq '/no-content-chunked') {
+				# Same body-less contract, chunked framing: the
+				# surplus is a well-formed chunked body nginx must
+				# neither forward nor treat as the next response.
+				print $client "HTTP/1.1 204 No Content\r\n"
+					. "Transfer-Encoding: chunked\r\n\r\n"
+					. "7\r\nBADBODY\r\n0\r\n\r\n";
+			} elsif ($uri eq '/plain') {
+				my $body = "PLAIN-OK\n";
+				print $client "HTTP/1.1 200 OK\r\n"
+					. "Content-Length: " . length($body) . "\r\n\r\n"
+					. $body;
+			} else {
+				open(my $fh, '>', $testdir . "/seen-unexpected");
+				close($fh);
+				print $client "HTTP/1.1 500 Internal Server Error\r\n"
+					. "Content-Length: 0\r\n\r\n";
+			}
+		}
+
+		close $client;
+	}
+}
+
+###############################################################################


### PR DESCRIPTION
## TL;DR

Add adversarial HTTP-framing coverage and exercise interim upstream responses on persistent connections. The tests use synchronized origin markers, direct origin-access evidence, bounded raw I/O, and strict response-integrity checks so stalled reads or partial responses cannot pass silently.

The original cases cover conflicting/repeated length framing, malformed chunked bodies, request boundaries, `100 Continue`, `103 Early Hints`, and upstream-connection reuse. A second differential corpus sends identical malformed bytes through `coraza on` and `coraza off`, proving seven core-rejected cases never reach the origin and that enabling Coraza is not weaker.

The differential coverage also checks a legal trailer, benign and WAF-block controls, and stacked/unknown response encodings with exact status, header, and body assertions. Truncated bodies explicitly half-close their write side; complete requests do not. Two surplus-byte cases were removed because they tested either `Connection: close` behavior or legal pipelining, not a frontend/backend parser disagreement.

**Severity:** None — test coverage only.

## Validation

- The added differential file passes Perl syntax and repository review/lint gates.
- Its 51 explicit assertions plus two Test::Nginx checks execute on the fork's nginx stable/mainline matrix.
- Sanitizer, fuzz, memcheck, CodeQL, and security-scanner jobs passed before the changes were forwarded here.

