### PR TITLE
perf: trim request and connection-header hot paths

### DIFF
--- a/src/ngx_http_coraza_header_filter.c
+++ b/src/ngx_http_coraza_header_filter.c
@@ -309,6 +309,7 @@ ngx_http_coraza_resolv_header_connection(ngx_http_request_t *r, ngx_str_t name, 
     ngx_http_coraza_ctx_t *ctx = NULL;
     ngx_http_core_loc_conf_t *clcf = NULL;
     char *connection = NULL;
+    size_t connection_len = 0;
     ngx_str_t value;
 
     clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
@@ -330,16 +331,23 @@ ngx_http_coraza_resolv_header_connection(ngx_http_request_t *r, ngx_str_t name, 
 
     if (r->headers_out.status == NGX_HTTP_SWITCHING_PROTOCOLS) {
         connection = "upgrade";
+        connection_len = sizeof("upgrade") - 1;
     } else if (r->keepalive) {
         connection = "keep-alive";
+        connection_len = sizeof("keep-alive") - 1;
         if (clcf->keepalive_header)
         {
             u_char buf[1024];
-            ngx_sprintf(buf, "timeout=%T%Z", clcf->keepalive_header);
+            u_char *p2;
             ngx_str_t name2 = ngx_string("Keep-Alive");
 
+            /* %Z writes the NUL terminator and ngx_sprintf returns a
+             * pointer past the last byte written, so (p2 - buf - 1) is the
+             * string length excluding that NUL -- no strlen() rescan. */
+            p2 = ngx_sprintf(buf, "timeout=%T%Z", clcf->keepalive_header);
+
             value.data = buf;
-            value.len = strlen((char *)buf);
+            value.len = (size_t) (p2 - buf - 1);
 
             if (ngx_http_coraza_add_response_header(r, ctx, &name2, &value)
                 != NGX_OK)
@@ -349,10 +357,11 @@ ngx_http_coraza_resolv_header_connection(ngx_http_request_t *r, ngx_str_t name, 
         }
     } else {
         connection = "close";
+        connection_len = sizeof("close") - 1;
     }
 
     value.data = (u_char *) connection;
-    value.len = strlen(connection);
+    value.len = connection_len;
 
     return ngx_http_coraza_add_response_header(r, ctx, &name, &value);
 }

--- a/src/ngx_http_coraza_pre_access.c
+++ b/src/ngx_http_coraza_pre_access.c
@@ -38,6 +38,16 @@ ngx_http_coraza_request_read(ngx_http_request_t *r)
 
 
 /*
+ * Reusable per-worker chunk buffer for ngx_http_coraza_append_request_body_file().
+ * nginx workers are single-threaded and this function never yields to the
+ * event loop between its use and its last read, so no two requests can be
+ * inside this function at once and the buffer needs no locking.
+ */
+static u_char ngx_http_coraza_request_body_file_chunk[
+    NGX_HTTP_CORAZA_REQUEST_BODY_FILE_CHUNK_SIZE];
+
+
+/*
  * Finish the request-body phase after any body submission.  This must also run
  * when request-body access is off: Coraza still evaluates phase-2 rules on
  * headers, URI arguments and other non-body variables in that case.
@@ -125,12 +135,7 @@ ngx_http_coraza_append_request_body_file(ngx_http_coraza_ctx_t *ctx,
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 
-    data = ngx_alloc(NGX_HTTP_CORAZA_REQUEST_BODY_FILE_CHUNK_SIZE,
-                     r->connection->log);
-    if (data == NULL) {
-        rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
-        goto done;
-    }
+    data = ngx_http_coraza_request_body_file_chunk;
 
     offset = 0;
     rc = NGX_OK;
@@ -147,7 +152,7 @@ ngx_http_coraza_append_request_body_file(ngx_http_coraza_ctx_t *ctx,
         n = ngx_read_file(&file, data, size, offset);
         if (n == NGX_ERROR) {
             rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
-            goto free;
+            goto done;
         }
 
         if (n == 0) {
@@ -155,7 +160,7 @@ ngx_http_coraza_append_request_body_file(ngx_http_coraza_ctx_t *ctx,
                 "coraza: file-buffered request body ended at %O of %O bytes",
                 offset, body_size);
             rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
-            goto free;
+            goto done;
         }
 
         if (coraza_append_request_body(ctx->coraza_transaction, data,
@@ -165,7 +170,7 @@ ngx_http_coraza_append_request_body_file(ngx_http_coraza_ctx_t *ctx,
                 "coraza: failed to append file-buffered request body chunk "
                 "for inspection");
             rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
-            goto free;
+            goto done;
         }
 
         offset += n;
@@ -174,19 +179,15 @@ ngx_http_coraza_append_request_body_file(ngx_http_coraza_ctx_t *ctx,
             ret = ngx_http_coraza_process_intervention(ctx, r, 0);
             if (ret < 0) {
                 rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
-                goto free;
+                goto done;
             }
             if (ret > 0) {
                 ctx->intervention_triggered = 1;
                 rc = ret;
-                goto free;
+                goto done;
             }
         }
     }
-
-free:
-
-    ngx_free(data);
 
 done:
 
@@ -265,8 +266,6 @@ ngx_http_coraza_pre_access_handler(ngx_http_request_t *r)
 
         dd("asking for the request body, if any. Count: %d",
             r->main->count);
-        /* Ensure the full request body lands in a single buffer for inspection */
-        r->request_body_in_single_buf = 1;
         r->request_body_in_persistent_file = 1;
         if (!r->request_body_in_file_only) {
             // If the above condition fails, then the flag below will have been
@@ -352,7 +351,10 @@ ngx_http_coraza_pre_access_handler(ngx_http_request_t *r)
              * (libcoraza signals failure with a positive sentinel, so test
              * != 0, not < 0.)
              */
-            if (coraza_append_request_body(ctx->coraza_transaction, data, blen) != 0) {
+            if (blen > 0
+                && coraza_append_request_body(ctx->coraza_transaction, data,
+                                              blen) != 0)
+            {
                 ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                     "coraza: failed to append request body chunk for inspection");
                 ctx->intervention_triggered = 1;

--- a/src/ngx_http_coraza_rewrite.c
+++ b/src/ngx_http_coraza_rewrite.c
@@ -84,11 +84,15 @@ ngx_http_coraza_rewrite_handler(ngx_http_request_t *r)
             server_addr = "unix";
         } else {
             u_char addr[NGX_SOCKADDR_STRLEN];
-            ngx_server_addr.len = NGX_SOCKADDR_STRLEN;
+
+            /* The unconditional call above already populated
+             * connection->local_sockaddr/local_socklen, so format that
+             * cached address directly. A second helper call has no new
+             * address to discover and ultimately reaches the same
+             * ngx_sock_ntop() formatting step. */
+            ngx_server_addr.len = ngx_sock_ntop(connection->local_sockaddr,
+                connection->local_socklen, addr, NGX_SOCKADDR_STRLEN, 0);
             ngx_server_addr.data = addr;
-            if (ngx_connection_local_sockaddr(r->connection, &ngx_server_addr, 0) != NGX_OK) {
-                return NGX_HTTP_INTERNAL_SERVER_ERROR;
-            }
             server_port = ngx_inet_get_port(connection->local_sockaddr);
             if (ngx_str_to_char(ngx_server_addr, &server_addr, r->pool) != NGX_OK) {
                 return NGX_HTTP_INTERNAL_SERVER_ERROR;

--- a/t/coraza-request-body-reader-contract.t
+++ b/t/coraza-request-body-reader-contract.t
@@ -34,8 +34,16 @@ like($pre_access,
 	'temp-file reader stops promptly on an intervention');
 
 like($pre_access,
-	qr/ngx_alloc\(NGX_HTTP_CORAZA_REQUEST_BODY_FILE_CHUNK_SIZE,.*?while \(offset < body_size\).*?ngx_free\(data\)/s,
-	'temp-file reader reuses and releases one chunk buffer');
+	qr/static u_char ngx_http_coraza_request_body_file_chunk\[\s*NGX_HTTP_CORAZA_REQUEST_BODY_FILE_CHUNK_SIZE\]/s,
+	'temp-file reader declares one per-worker static chunk buffer');
+
+like($pre_access,
+	qr/data\s*=\s*ngx_http_coraza_request_body_file_chunk\s*;/,
+	'temp-file reader uses the per-worker static chunk buffer');
+
+unlike($pre_access,
+	qr/ngx_alloc\(NGX_HTTP_CORAZA_REQUEST_BODY_FILE_CHUNK_SIZE|ngx_free\(data\)/,
+	'temp-file reader does not allocate or free a per-request chunk buffer');
 
 unlike($pre_access, qr/\bcoraza_request_body_from_file\b/,
 	'pre-access path no longer delegates file reads to libcoraza');


### PR DESCRIPTION
## TL;DR

Large request bodies and common connection-header handling do small amounts of avoidable work on every request or response. This sweep reuses scratch storage and carries already-known address and header values forward without changing inspection behavior.

**Severity:** Low (performance and cleanup; request behavior is unchanged)

## Request body

- The file-backed reader uses one worker-lifetime 64 KiB buffer instead of allocating and freeing scratch space per request. The reader is synchronous on nginx's single-threaded worker loop, so requests cannot overlap inside it.
- Empty in-memory buffers no longer cross into libcoraza. End-of-chain handling still runs for every buffer, including an empty final buffer.
- `request_body_in_single_buf` is no longer set. On supported nginx versions it does not control the memory/file split or body-chain shape.
- The reader retains its private file descriptor because `ngx_read_file()` advances `ngx_file_t.offset` bookkeeping even when the platform uses `pread()`.

## Connection metadata

- The rewrite handler formats the local address already cached by its first `ngx_connection_local_sockaddr()` call instead of re-entering the helper.
- The header filter uses `sizeof(literal) - 1` for Connection values and the end pointer returned by `ngx_sprintf()` for Keep-Alive, avoiding follow-up string scans.
- Unix-domain handling and the HTTP/2 and HTTP/3 early-return behavior are unchanged.
