### PR TITLE
perf: deduplicate WAFs by ordered rule content

### DIFF
--- a/src/ngx_http_coraza_common.h
+++ b/src/ngx_http_coraza_common.h
@@ -111,6 +111,17 @@ typedef struct {
     coraza_waf_t               waf;
     ngx_array_t               *rules;       /* of ngx_http_coraza_rule_entry_t */
 
+    /*
+     * WAF ownership.  init_process dedups WAFs across loc_confs whose rules
+     * arrays are content-identical, so several loc_confs can point at the
+     * same coraza_waf_t.  Exactly one of them -- the one that actually built
+     * it -- has waf_owner set, and only that one frees the handle in
+     * exit_process.  Sharers leave waf_owner clear and must never free.
+     * A loc_conf that falls back to mmcf->waf is never an owner either;
+     * mmcf owns that handle.
+     */
+    ngx_flag_t                 waf_owner;
+
     ngx_flag_t                 enable;
     ngx_flag_t                 has_rules;
     ngx_flag_t                 delay_response_headers;

--- a/src/ngx_http_coraza_module.c
+++ b/src/ngx_http_coraza_module.c
@@ -562,6 +562,7 @@ ngx_http_coraza_create_conf(ngx_conf_t *cf)
 	 *     conf->transaction_id = NULL;
 	 *     conf->has_rules = 0;
 	 *     conf->delay_response_headers = 0;
+	 *     conf->waf_owner = 0;
 	 */
 
 	conf->enable = NGX_CONF_UNSET;
@@ -665,6 +666,53 @@ ngx_http_coraza_merge_conf(ngx_conf_t *cf, void *parent, void *child)
 /* ------------------------------------------------------------------ */
 /* Helper: build a WAF from a rules array                              */
 /* ------------------------------------------------------------------ */
+
+/*
+ * Two rules arrays produce the same WAF iff they carry the same ordered
+ * sequence of (type, value) entries.  Order is significant: SecLang is
+ * sequential, so [a,b] and [b,a] are different rulesets and must not merge.
+ *
+ * Comparing the stored strings is sufficient here because the connector never
+ * resolves a rules path against the including config's context: both
+ * ngx_conf_set_rules() and ngx_conf_set_rules_file() ngx_pstrdup() the raw
+ * token, and ngx_http_coraza_build_waf() hands that same byte sequence to
+ * coraza_rules_add()/coraza_rules_add_file() in the worker.  A relative path
+ * is therefore resolved by libcoraza from the worker's cwd, which is identical
+ * for every loc_conf in the cycle -- so identical text means identical meaning.
+ * If that ever stops holding (e.g. a directive gains context-dependent
+ * resolution at parse time), this comparison must be tightened or dropped:
+ * dedup is an optimization, and refusing to merge is always correct.
+ */
+static ngx_int_t
+ngx_http_coraza_rules_equal(ngx_array_t *a, ngx_array_t *b)
+{
+	ngx_http_coraza_rule_entry_t *ea, *eb;
+	ngx_uint_t i;
+
+	if (a == b) {
+		return 1;               /* pointer-identity fast path */
+	}
+
+	if (a == NULL || b == NULL || a->nelts != b->nelts) {
+		return 0;
+	}
+
+	ea = a->elts;
+	eb = b->elts;
+
+	for (i = 0; i < a->nelts; i++) {
+		if (ea[i].type != eb[i].type
+			|| ea[i].value.len != eb[i].value.len
+			|| ngx_memcmp(ea[i].value.data, eb[i].value.data,
+						  ea[i].value.len) != 0)
+		{
+			return 0;
+		}
+	}
+
+	return 1;
+}
+
 
 static coraza_waf_t
 ngx_http_coraza_build_waf(ngx_array_t *rules, ngx_log_t *log)
@@ -793,12 +841,28 @@ ngx_http_coraza_init_process(ngx_cycle_t *cycle)
 			continue;
 		}
 
-		/* Check if another loc_conf already built this exact rules array */
+		/*
+		 * Reuse a WAF another loc_conf already built when the two rules
+		 * arrays are content-identical.  Sharing the same pointer is the
+		 * cheap case (config inheritance already gives it to us); distinct
+		 * arrays that spell out the same directives in the same order are
+		 * the case this catches, and it is the common one -- n server
+		 * blocks each naming the same CRS bundle used to compile CRS n
+		 * times and hold n copies of it in every worker.
+		 *
+		 * Only owners are considered as donors, so the borrowed handle is
+		 * always one with a live owner responsible for freeing it exactly
+		 * once (see waf_owner in ngx_http_coraza_common.h).
+		 */
 		ngx_uint_t j;
 		ngx_int_t found = 0;
 		for (j = 0; j < i; j++) {
-			if (loc_confs[j]->rules == lcf->rules && loc_confs[j]->waf != 0) {
+			if (loc_confs[j]->waf_owner && loc_confs[j]->waf != 0
+				&& ngx_http_coraza_rules_equal(loc_confs[j]->rules,
+											   lcf->rules))
+			{
 				lcf->waf = loc_confs[j]->waf;
+				lcf->waf_owner = 0;     /* borrower: must not free */
 				found = 1;
 				break;
 			}
@@ -813,6 +877,7 @@ ngx_http_coraza_init_process(ngx_cycle_t *cycle)
 						  "coraza: failed to build loc WAF in worker");
 			return NGX_ERROR;
 		}
+		lcf->waf_owner = 1;             /* this loc_conf built it: it frees it */
 		ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0,
 					  "coraza: loc WAF initialized with %d rules",
 					  coraza_rules_count(lcf->waf));
@@ -843,34 +908,29 @@ ngx_http_coraza_exit_process(ngx_cycle_t *cycle)
 		return;
 	}
 
-	/* Free loc_conf WAFs, skipping shared ones.
-	 * Walk the array twice: first pass frees unique WAFs,
-	 * second pass zeroes all pointers.  This avoids a double-free
-	 * bug where zeroing waf in the first pass defeats the dedup check
-	 * for later loc_confs that share the same handle. */
+	/*
+	 * Free loc_conf WAFs.  Ownership is explicit: init_process set
+	 * waf_owner on exactly the one loc_conf that built each distinct WAF,
+	 * and left it clear on every loc_conf that borrowed a handle or fell
+	 * back to mmcf->waf.  Freeing owners only therefore frees each distinct
+	 * WAF exactly once -- no double free, no leak -- without the O(n^2)
+	 * pointer scan this used to need.  mmcf->waf is owned by mmcf and is
+	 * freed separately below; a loc_conf never owns it.
+	 *
+	 * Pointers are zeroed in a second pass so that nothing observes a
+	 * dangling handle between the two loops.
+	 */
 	loc_confs = mmcf->loc_confs->elts;
 	for (i = 0; i < mmcf->loc_confs->nelts; i++) {
 		ngx_http_coraza_conf_t *lcf = loc_confs[i];
 
-		if (lcf->waf == 0 || lcf->waf == mmcf->waf) {
-			continue;
-		}
-
-		/* Check if an earlier loc_conf already freed this WAF */
-		ngx_uint_t j;
-		ngx_int_t shared = 0;
-		for (j = 0; j < i; j++) {
-			if (loc_confs[j]->waf == lcf->waf) {
-				shared = 1;
-				break;
-			}
-		}
-		if (!shared) {
+		if (lcf->waf_owner && lcf->waf != 0 && lcf->waf != mmcf->waf) {
 			coraza_free_waf(lcf->waf);
 		}
 	}
 	for (i = 0; i < mmcf->loc_confs->nelts; i++) {
 		loc_confs[i]->waf = 0;
+		loc_confs[i]->waf_owner = 0;
 	}
 
 	/* Free main WAF */

--- a/src/ngx_http_coraza_module.c
+++ b/src/ngx_http_coraza_module.c
@@ -539,6 +539,10 @@ ngx_http_coraza_init_main_conf(ngx_conf_t *cf, void *conf)
 	return NGX_CONF_OK;
 }
 
+/**
+ * Allocate a location configuration.  The zeroed waf_owner field is part of
+ * the lifecycle contract: a location owns no WAF until init_process builds one.
+ */
 static void *
 ngx_http_coraza_create_conf(ngx_conf_t *cf)
 {
@@ -714,6 +718,10 @@ ngx_http_coraza_rules_equal(ngx_array_t *a, ngx_array_t *b)
 }
 
 
+/**
+ * Compile the ordered rule entries into one WAF.  Configuration or build
+ * failures are logged here and returned as a null handle to init_process.
+ */
 static coraza_waf_t
 ngx_http_coraza_build_waf(ngx_array_t *rules, ngx_log_t *log)
 {

--- a/t/coraza-waf-dedup.t
+++ b/t/coraza-waf-dedup.t
@@ -1,0 +1,224 @@
+#!/usr/bin/perl
+
+# (C) Thijs Eilander
+
+# Tests for Coraza-nginx connector: WAFs are deduplicated by rule *content*,
+# not by rules-array pointer identity.
+#
+# Two server blocks that spell out byte-identical coraza_rules directives get
+# distinct ngx_array_t rules arrays from the config parser, so the old
+# pointer-identity check never matched them and the connector compiled the
+# ruleset once per block.  Content comparison collapses those into one WAF.
+#
+# The negative control is the load-bearing half: blocks with *different* rules
+# must keep separate WAFs, so a rule declared in one block must not fire in
+# the other.  An over-eager dedup would silently merge distinct policies, and
+# nothing else in the suite would notice.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+use IO::Socket::INET;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http/)->plan(12);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+error_log %%TESTDIR%%/error.log notice;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    coraza on;
+
+    # --- Two blocks with byte-identical rules: must share one WAF. ---
+
+    server {
+        listen       127.0.0.1:%%PORT_8080%%;
+        server_name  dedup_a;
+
+        coraza_rules '
+            SecRuleEngine On
+            SecRule REQUEST_URI "@contains /shared-attack" "id:1001,phase:1,deny,log,status:403,t:none"
+        ';
+
+        location / {
+            return 200 "OK-A\n";
+        }
+    }
+
+    server {
+        listen       127.0.0.1:%%PORT_8081%%;
+        server_name  dedup_b;
+
+        coraza_rules '
+            SecRuleEngine On
+            SecRule REQUEST_URI "@contains /shared-attack" "id:1001,phase:1,deny,log,status:403,t:none"
+        ';
+
+        location / {
+            return 200 "OK-B\n";
+        }
+    }
+
+    # --- Negative control: different rules, must NOT share. ---
+    #
+    # Block C denies /only-in-c.  Block D denies /only-in-d.  If dedup merged
+    # them, one block's rule would start firing in the other.
+
+    server {
+        listen       127.0.0.1:%%PORT_8082%%;
+        server_name  distinct_c;
+
+        coraza_rules '
+            SecRuleEngine On
+            SecRule REQUEST_URI "@contains /only-in-c" "id:2001,phase:1,deny,log,status:403,t:none"
+        ';
+
+        location / {
+            return 200 "OK-C\n";
+        }
+    }
+
+    server {
+        listen       127.0.0.1:%%PORT_8083%%;
+        server_name  distinct_d;
+
+        coraza_rules '
+            SecRuleEngine On
+            SecRule REQUEST_URI "@contains /only-in-d" "id:2002,phase:1,deny,log,status:403,t:none"
+        ';
+
+        location / {
+            return 200 "OK-D\n";
+        }
+    }
+
+    # --- Order control: same two rules, opposite order. ---
+    #
+    # In E, the SecAction sets tx.order_probe before the SecRule reads it, so
+    # /order-probe is denied.  In F, the SecRule runs before the variable is
+    # set and the request passes.  A comparison that ignores order would merge
+    # the two WAFs and make one server use the other's policy.
+
+    server {
+        listen       127.0.0.1:%%PORT_8084%%;
+        server_name  order_e;
+
+        coraza_rules 'SecRuleEngine On';
+        coraza_rules 'SecAction "id:3001,phase:1,pass,nolog,setvar:tx.order_probe=1"';
+        coraza_rules 'SecRule TX:order_probe "@eq 1" "id:3002,phase:1,deny,nolog,status:403,t:none"';
+
+        location / {
+            return 200 "OK-E\n";
+        }
+    }
+
+    server {
+        listen       127.0.0.1:%%PORT_8085%%;
+        server_name  order_f;
+
+        coraza_rules 'SecRuleEngine On';
+        coraza_rules 'SecRule TX:order_probe "@eq 1" "id:3002,phase:1,deny,nolog,status:403,t:none"';
+        coraza_rules 'SecAction "id:3001,phase:1,pass,nolog,setvar:tx.order_probe=1"';
+
+        location / {
+            return 200 "OK-F\n";
+        }
+    }
+}
+
+EOF
+
+$t->run();
+
+###############################################################################
+
+# --- Sharing: identical blocks both enforce. ---
+
+like(http_get('/shared-attack', socket => port_socket(8080)), qr/ 403 /,
+	'identical block A blocks the hostile request');
+like(http_get('/shared-attack', socket => port_socket(8081)), qr/ 403 /,
+	'identical block B blocks the hostile request');
+like(http_get('/benign', socket => port_socket(8080)), qr/OK-A/,
+	'identical block A passes a benign request');
+like(http_get('/benign', socket => port_socket(8081)), qr/OK-B/,
+	'identical block B passes a benign request');
+
+# --- NEGATIVE CONTROL: distinct blocks did not merge. ---
+
+like(http_get('/only-in-c', socket => port_socket(8082)), qr/ 403 /,
+	'control: block C enforces its own rule');
+like(http_get('/only-in-c', socket => port_socket(8083)), qr/OK-D/,
+	'control: block C rule does NOT fire in block D');
+like(http_get('/only-in-d', socket => port_socket(8083)), qr/ 403 /,
+	'control: block D enforces its own rule');
+like(http_get('/only-in-d', socket => port_socket(8082)), qr/OK-C/,
+	'control: block D rule does NOT fire in block C');
+
+# --- ORDER CONTROL: the same two rules have different sequential effects. ---
+
+like(http_get('/order-probe', socket => port_socket(8084)), qr/ 403 /,
+	'order E sets the transaction variable before the deny rule reads it');
+like(http_get('/order-probe', socket => port_socket(8085)), qr/OK-F/,
+	'order F evaluates the deny rule before the variable is set');
+
+# --- The sharing itself, observed in the worker's startup log. ---
+#
+# ngx_http_coraza_init_process() logs one "loc WAF initialized" line per WAF
+# it actually builds, and one "main WAF initialized" line per worker.
+#
+# Twelve rule-bearing loc_confs reach init_process: one per server plus one per
+# location, because each location inherits its server's rules pointer.  The six
+# inherited locations already share through pointer identity, so the observed
+# pre-change count was six distinct WAFs per worker.  A and B have identical
+# content in distinct arrays, so content comparison reduces that count to five.
+#
+# Normalise by the worker count: the harness may start more than one worker,
+# and init_process runs once in each.
+
+my $log = $t->read_file('error.log');
+my $workers = () = $log =~ /main WAF initialized/g;
+my $built   = () = $log =~ /loc WAF initialized/g;
+
+cmp_ok($workers, '>', 0, 'at least one worker reported WAF initialization');
+
+is($built, 5 * $workers,
+	"per worker: 6 distinct rules arrays produced "
+	. ($workers ? $built / $workers : $built)
+	. " WAFs (5 expected: A and B share one)");
+
+###############################################################################
+
+sub port_socket {
+	my ($port) = @_;
+	my $s = IO::Socket::INET->new(
+		Proto => 'tcp',
+		PeerAddr => '127.0.0.1',
+		PeerPort => port($port),
+	) or die "Can't connect to nginx: $!\n";
+
+	return $s;
+}
+
+###############################################################################


### PR DESCRIPTION
## TL;DR

Several server blocks that load identical firewall rules currently compile and store separate copies. This change shares one compiled copy when the ordered rule text is identical, while different or differently ordered policies remain separate.

**Severity:** Low (startup time and per-worker memory use)

## Mechanism

`ngx_http_coraza_init_process()` first checks rules-array pointer identity, then compares the ordered `(type, value)` entries. Rule order remains part of the key because SecLang evaluates rules sequentially.

The comparison uses the stored directive text. Both rule setters preserve the raw token, and `ngx_http_coraza_build_waf()` passes that same text to libcoraza from a single worker working directory. If path resolution becomes context-dependent, the comparison must be tightened or removed.

## Ownership

`waf_owner` marks the location configuration that built each handle. Borrowers keep the owner bit clear, and `exit_process()` frees only owners, so every shared handle has one release. The main configuration retains ownership of its fallback handle.

`t/coraza-waf-dedup.t` covers identical policies, distinct policies, and the same two stateful rules in opposite order. The order pair has different request outcomes, so both the policy result and the WAF initialization count detect an incorrect merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved resource usage by reusing Web Application Firewall instances when configurations contain identical rules.

* **Bug Fixes**
  * Ensured configurations with different rules, or the same rules in a different order, remain separately evaluated.
  * Improved WAF lifecycle handling to prevent duplicate cleanup and preserve reliable worker shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->