### PR TITLE
fix: use libcoraza's interruption result and required bulk APIs

### DIFF
--- a/src/ngx_http_coraza_common.h
+++ b/src/ngx_http_coraza_common.h
@@ -82,7 +82,8 @@ typedef struct {
     /* When non-NULL, ngx_http_coraza_add_response_header() collects pairs
      * here instead of making one cgo call each, so the header filter can
      * submit the whole set via coraza_add_response_headers() in a single
-     * crossing (libcoraza 1.6+).  NULL => direct per-header cgo path. */
+     * crossing.  It is NULL outside collection, during fallback replay, or
+     * when ngx_array_create() cannot arm the collector. */
     ngx_array_t *resp_hdr_collect;
 
     unsigned waiting_more_body:1;
@@ -174,47 +175,60 @@ ngx_int_t ngx_http_coraza_process_intervention (ngx_http_coraza_ctx_t *ctx, ngx_
 ngx_http_coraza_ctx_t *ngx_http_coraza_create_ctx(ngx_http_request_t *r);
 
 /*
- * CORAZA_INTERRUPTION is the coraza_result_t value libcoraza 1.6+ returns from
+ * CORAZA_INTERRUPTION is the coraza_result_t value libcoraza returns from
  * coraza_process_{request_headers,request_body,response_headers,response_body}
  * when a rule interrupted the transaction (added upstream b3fedde3, the same
- * commit that added the bulk-header symbols). Older libcoraza headers (<1.6) do
- * NOT define the coraza_result_t enum, so provide a local fallback of the stable
- * value (1) to keep the connector compilable against a 1.4 header. The value is
- * only consulted on a bulk-capable (>=1.6) library — see
- * ngx_http_coraza_poll_after_process() below — so the fallback is never trusted
- * as a real signal on an old lib.
+ * commit that added the bulk-header symbols). It is an *enumerator* of
+ * `enum coraza_result_t` in coraza.h, not a preprocessor macro, so it must
+ * never be given a local `#ifndef CORAZA_INTERRUPTION` fallback: that guard
+ * is true on every build, and the literal it defines would textually shadow
+ * the library's own value at every use site. The connector would then compare
+ * against a hardcoded constant and silently fail open if libcoraza ever
+ * renumbered the enum. libcoraza >= 1.7 is a hard floor (enforced in the
+ * addon `config` build probe and again at runtime in
+ * ngx_http_coraza_dl_open), and coraza.h is included above, so the enumerator
+ * is always in scope and the comparison below binds to the real value.
  */
-#ifndef CORAZA_INTERRUPTION
-#define CORAZA_INTERRUPTION 1
-#endif
 
 /*
  * ngx_http_coraza_poll_after_process — CGO-thrifty intervention poll for the
  * four rule-phase entry points. Post phase, coraza_intervention() is almost
- * always NULL; on libcoraza 1.6+ the process fn already told us whether a rule
- * interrupted via its return value (pret), so we only cross into Go to fetch the
- * intervention when pret == CORAZA_INTERRUPTION. On <1.6 the return value is not
- * a reliable signal (request/response_headers always returned 0, the body fns
- * returned 1 only on error), so we MUST fall back to an unconditional poll —
- * gating on the return there would fail open and skip a real block. The 1.6+
- * guarantee is proxied by ngx_http_coraza_bulk_headers_available() (same commit
- * introduced both). Semantics are otherwise identical to a bare
- * ngx_http_coraza_process_intervention() call: returns NGX_OK / >0 status /
- * NGX_ERROR exactly as that helper does, so callers keep their existing
- * error_page and ret handling.
+ * always NULL; the process fn already told us whether a rule interrupted via
+ * its return value (pret), so we only cross into Go to fetch the
+ * intervention when pret == CORAZA_INTERRUPTION. This relies on the
+ * mandatory >= 1.7 floor (see CORAZA_INTERRUPTION above and
+ * ngx_http_coraza_dl_open): on that guarantee the return value is always a
+ * reliable signal, so no runtime capability check is needed here. Semantics
+ * are otherwise identical to a bare ngx_http_coraza_process_intervention()
+ * call: returns NGX_OK / >0 status / NGX_ERROR exactly as that helper does,
+ * so callers keep their existing error_page and ret handling.
  */
-/* Forward declaration (full prototype in the ngx_http_coraza_dl.c block below);
- * needed here because the inline poll helper calls it under -Werror. */
-int ngx_http_coraza_bulk_headers_available(void);
-
 static ngx_inline ngx_int_t
 ngx_http_coraza_poll_after_process(ngx_http_coraza_ctx_t *ctx,
     ngx_http_request_t *r, ngx_int_t early_log, int pret)
 {
-    if (ngx_http_coraza_bulk_headers_available()
-        && pret != CORAZA_INTERRUPTION)
+    if (pret < 0) {
+        /*
+         * CORAZA_ERROR: the phase was not evaluated at all, so no
+         * interruption is set and the CORAZA_OK path below would wave the
+         * request through uninspected. Fail closed, the same disposition the
+         * two body call sites already take via
+         * ngx_http_coraza_process_body_failed() before they get here.
+         *
+         * Unreachable on libcoraza 1.7.0, whose
+         * coraza_process_{request,response}_headers return only CORAZA_OK or
+         * CORAZA_INTERRUPTION (coraza.go:380-387, 482-489). It is here so
+         * that an error return added upstream later is a 500 rather than a
+         * silent skip.
+         */
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+            "coraza: rule phase processing failed (%d)", pret);
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    if (pret != CORAZA_INTERRUPTION)
     {
-        /* 1.6+ said OK: no rule interrupted this phase, nothing to fetch. */
+        /* No rule interrupted this phase: nothing to fetch. */
         return NGX_OK;
     }
 
@@ -226,11 +240,12 @@ ngx_int_t ngx_http_coraza_dl_open(ngx_log_t *log);
 void ngx_http_coraza_dl_close(ngx_log_t *log);
 int ngx_http_coraza_is_request_body_accessible(coraza_transaction_t t);
 int ngx_http_coraza_is_response_body_processable(coraza_transaction_t t);
-/* Bulk header entry points (libcoraza 1.6+); guard every call with
- * ngx_http_coraza_bulk_headers_available() (forward-declared above). */
-/* NOTE: `packed` is non-const to match libcoraza's SWIG-generated 1.6 header
- * (which declares `char *packed`); a `const char *` here trips -Werror
- * conflicting-types when the connector is built against the real 1.6 header. */
+/* Bulk header entry points. Both are loaded with the mandatory DL_SYM in
+ * ngx_http_coraza_dl_open() and require the enforced >= 1.7.0 floor, so they
+ * are always available -- no runtime capability check needed. */
+/* NOTE: `packed` is non-const to match libcoraza's generated header, which
+ * declares `char *packed`; a `const char *` here trips -Werror
+ * conflicting-types. */
 int coraza_add_request_headers(coraza_transaction_t t, char *packed,
     int packed_len, int count);
 int coraza_add_response_headers(coraza_transaction_t t, char *packed,

--- a/src/ngx_http_coraza_dl.c
+++ b/src/ngx_http_coraza_dl.c
@@ -402,35 +402,23 @@ ngx_http_coraza_is_response_body_processable(coraza_transaction_t t)
 }
 
 /*
- * Bulk header wrappers (libcoraza 1.6+).  These forward to the resolved
- * symbols; callers must first check ngx_http_coraza_bulk_headers_available()
- * because the pointers may be NULL on an older library.
+ * Bulk header wrappers.  These forward directly to the resolved symbols:
+ * both are loaded with the mandatory DL_SYM (see ngx_http_coraza_dl_open()
+ * above), so dl_add_request_headers / dl_add_response_headers are guaranteed
+ * non-NULL here -- a library that does not export them, or that is older
+ * than the enforced 1.7.0 floor, fails dl_open and the worker never starts.
+ * A negative return here is therefore always a genuine runtime pack/submit
+ * failure reported by libcoraza, not a missing symbol; callers already treat
+ * it as the signal to replay per-header.
  */
 int coraza_add_request_headers(coraza_transaction_t t, char *packed,
                                int packed_len, int count)
 {
-    if (dl_add_request_headers == NULL) {
-        return -1;
-    }
     return dl_add_request_headers(t, packed, packed_len, count);
 }
 
 int coraza_add_response_headers(coraza_transaction_t t, char *packed,
                                 int packed_len, int count)
 {
-    if (dl_add_response_headers == NULL) {
-        return -1;
-    }
     return dl_add_response_headers(t, packed, packed_len, count);
-}
-
-/*
- * ngx_http_coraza_bulk_headers_available — 1 when the loaded libcoraza
- * exports both bulk-header entry points, 0 otherwise.  Callers use the
- * per-header path when this returns 0.
- */
-int
-ngx_http_coraza_bulk_headers_available(void)
-{
-    return dl_add_request_headers != NULL && dl_add_response_headers != NULL;
 }

--- a/src/ngx_http_coraza_header_filter.c
+++ b/src/ngx_http_coraza_header_filter.c
@@ -76,8 +76,9 @@ ngx_http_coraza_add_response_header(ngx_http_request_t *r,
 
     /*
      * Bulk path: buffer the pair for a single coraza_add_response_headers()
-     * crossing later, rather than one cgo call per header.  The collector is
-     * armed by the header filter only when libcoraza exposes the bulk symbol.
+     * crossing later, rather than one cgo call per header.  The bulk entry
+     * points are mandatory symbols, so the header filter arms the collector
+     * unconditionally and only an allocation failure leaves it NULL.
      *
      * Copy name and value into r->pool: several resolvers synthesize their
      * value in a function-local stack buffer (Content-Length, Last-Modified,
@@ -444,19 +445,16 @@ ngx_http_coraza_header_filter(ngx_http_request_t *r)
     ctx->processed = 1;
 
     /*
-     * Arm the bulk collector when libcoraza can take all response headers in
-     * one cgo crossing (1.6+).  Every ngx_http_coraza_add_response_header()
-     * below then buffers into ctx->resp_hdr_collect instead of crossing per
-     * header; we flush the whole set once, just before
-     * coraza_process_response_headers().  If arming fails (allocation) or the
-     * symbol is absent, resp_hdr_collect stays NULL and the per-header path is
-     * used unchanged.
+     * Arm the bulk collector so all response headers go in one cgo crossing.
+     * Every ngx_http_coraza_add_response_header() below then buffers into
+     * ctx->resp_hdr_collect instead of crossing per header; we flush the
+     * whole set once, just before coraza_process_response_headers(). If
+     * arming fails (allocation), resp_hdr_collect stays NULL and the
+     * per-header path is used unchanged.
      */
-    if (ngx_http_coraza_bulk_headers_available()) {
-        ctx->resp_hdr_collect = ngx_array_create(r->pool, 16,
-            sizeof(ngx_http_coraza_header_t));
-        /* NULL on failure is fine: falls back to the direct path. */
-    }
+    ctx->resp_hdr_collect = ngx_array_create(r->pool, 16,
+        sizeof(ngx_http_coraza_header_t));
+    /* NULL on failure is fine: falls back to the direct path. */
 
     /*
      *

--- a/src/ngx_http_coraza_rewrite.c
+++ b/src/ngx_http_coraza_rewrite.c
@@ -176,14 +176,13 @@ ngx_http_coraza_rewrite_handler(ngx_http_request_t *r)
         ngx_int_t  bulk_done = 0;
 
         /*
-         * Fast path (libcoraza 1.6+): pack every request header into one
-         * buffer and hand Coraza the whole set in a single cgo crossing,
-         * instead of one crossing per header.  Falls through to the
-         * per-header loop below if the bulk symbol is absent or the pack
-         * fails (e.g. an over-range header length -- treated as fail-closed
-         * there too).
+         * Fast path: pack every request header into one buffer and hand
+         * Coraza the whole set in a single cgo crossing, instead of one
+         * crossing per header.  Falls through to the per-header loop below
+         * if the pack fails (e.g. an over-range header length -- treated as
+         * fail-closed there too).
          */
-        if (ngx_http_coraza_bulk_headers_available()) {
+        {
             ngx_http_coraza_header_t *pairs;
             ngx_uint_t nheaders = 0;
             ngx_list_part_t *cp = part;

--- a/t/coraza-bulk-headers.t
+++ b/t/coraza-bulk-headers.t
@@ -1,12 +1,16 @@
 #!/usr/bin/perl
 
-# Tests for the Coraza-nginx bulk-header submission path (libcoraza 1.6+).
+# Tests for the Coraza-nginx bulk-header submission path (libcoraza >= 1.7).
 #
 # The connector packs every request / response header into a single buffer and
 # hands the whole set to Coraza in one cgo crossing via
 # coraza_add_request_headers() / coraza_add_response_headers(), instead of one
-# crossing per header.  When the running libcoraza predates 1.6 the bulk
-# symbols are absent and the connector falls back to the per-header path.
+# crossing per header.  libcoraza >= 1.7 is a hard floor and both bulk symbols
+# are mandatory, so there is no capability fallback left.  Three runtime
+# conditions still select the per-header path: the collector allocation
+# failing (ngx_array_create in the header filter, ngx_palloc of the pair array
+# in rewrite.c), the pack failing on an over-range header length, and the
+# submit returning CORAZA_ERROR.
 #
 # Correctness requirement: whichever path is taken, EVERY header must still be
 # inspected exactly once.  These tests drive a request carrying many request
@@ -59,7 +63,7 @@ http {
             coraza on;
             coraza_rules '
                 SecRuleEngine On
-                SecRule REQUEST_HEADERS:X-Probe "@streq blockme" "id:100,phase:1,deny,status:403,log"
+                SecRule REQUEST_HEADERS:X-Probe "@streq blockme" "id:100,phase:1,deny,status:403,log,t:none"
             ';
             return 200 "ok";
         }
@@ -71,7 +75,7 @@ http {
             coraza on;
             coraza_rules '
                 SecRuleEngine On
-                SecRule RESPONSE_HEADERS:X-Secret "@streq leak" "id:200,phase:3,deny,status:403,log"
+                SecRule RESPONSE_HEADERS:X-Secret "@streq leak" "id:200,phase:3,deny,status:403,log,t:none"
             ';
             add_header X-Secret "leak";
             return 200 "ok";
@@ -83,8 +87,8 @@ http {
             coraza on;
             coraza_rules '
                 SecRuleEngine On
-                SecRule REQUEST_HEADERS:X-Probe "@streq blockme" "id:100,phase:1,deny,status:403,log"
-                SecRule RESPONSE_HEADERS:X-Secret "@streq leak" "id:200,phase:3,deny,status:403,log"
+                SecRule REQUEST_HEADERS:X-Probe "@streq blockme" "id:100,phase:1,deny,status:403,log,t:none"
+                SecRule RESPONSE_HEADERS:X-Secret "@streq leak" "id:200,phase:3,deny,status:403,log,t:none"
             ';
             add_header X-Secret "safe";
             return 200 "ok";
@@ -134,22 +138,22 @@ EOF
 like($benign, qr!^HTTP/\S+ 200!,
     'bulk path: benign request+response passes both rules');
 
-# Report which path the assertions above actually exercised, and make the bulk
-# path a first-class assertion when it is available. The bulk symbols exist only
-# in libcoraza >= 1.6; on an older runtime (e.g. the v1.4.0 the upstream CI still
-# pins) the connector falls back to the per-header path. Rather than accept
-# "(yes|no)" — which would let the feature under test go silently untested when
-# the symbols vanish — we branch: assert "yes" when the capability is present,
-# and SKIP explicitly (never silently pass) when it is absent.
 my $log = $t->read_file('error.log');
 
-# libcoraza >= 1.7 is required and the bulk-header entry points are mandatory
-# symbols (ngx_http_coraza_dl_open fails to load otherwise), so a successful
-# load means the assertions above really exercised the bulk path.
+# Rule out the one path-selection cause a black-box test can rule out: the
+# bulk entry points being absent.  They are mandatory symbols, so a successful
+# load proves they resolved.
+#
+# This is a proxy, not a path trace.  It does not prove the collector
+# allocation succeeded, and under memory pressure the connector would take the
+# per-header path and still satisfy every assertion above.  That is by design:
+# the point of the assertions is that both paths inspect every header exactly
+# once, so either one passing is the correct outcome.  Distinguishing them
+# would need a pool-allocation failure injection hook, which does not exist,
+# or a log line emitted purely for the test.
 if ($log =~ /coraza: \S+ loaded via dynlib_open \(libcoraza (\d+)\.(\d+)\.\d+\)/) {
     ok($1 > 1 || ($1 == 1 && $2 >= 7),
-        "libcoraza $1.$2 loaded (>= 1.7): bulk-header symbols resolved, "
-        . 'bulk path exercised above');
+        "libcoraza $1.$2 loaded (>= 1.7): bulk-header symbols resolved");
 } else {
     fail('connector did not log the libcoraza version at load');
 }

--- a/t/coraza-dynlib-contract.t
+++ b/t/coraza-dynlib-contract.t
@@ -35,6 +35,18 @@ like($dl, qr/DL_SYM\(dl_is_request_body_accessible,\s*coraza_is_request_body_acc
 like($dl, qr/return\s+dl_is_request_body_accessible\(t\)/,
 	'request-body helper wrapper calls the resolved symbol');
 
+# The bulk-header wrappers dereference these pointers unconditionally -- the
+# NULL guards were removed once >= 1.7 became a hard floor -- so a downgrade to
+# DL_SYM_OPT would turn the first header-bearing request into a NULL call.
+like($dl, qr/DL_SYM\(dl_add_request_headers,\s*coraza_add_request_headers\)/s,
+	'bulk request-header entry point is resolved as a required symbol');
+
+like($dl, qr/DL_SYM\(dl_add_response_headers,\s*coraza_add_response_headers\)/s,
+	'bulk response-header entry point is resolved as a required symbol');
+
+unlike($dl, qr/DL_SYM_OPT\([^,]+,\s*coraza_add_(?:request|response)_headers\)/s,
+	'bulk header entry points are not downgraded to optional symbols');
+
 unlike($dl, qr/DL_SYM\([^,]+,\s*coraza_rules_merge\)/,
 	'dead coraza_rules_merge symbol is not required at startup');
 

--- a/t/coraza-intervention-poll.t
+++ b/t/coraza-intervention-poll.t
@@ -15,11 +15,11 @@
 #      would stop blocking. They must still return 403.
 #
 #  (B) The post-phase polls (request-headers, request-body, response-headers,
-#      response-body) now skip the CGO intervention fetch when the running
-#      libcoraza is 1.6+ AND the process fn returned != CORAZA_INTERRUPTION. On an
-#      older library the return value is not a reliable interruption signal, so
-#      the connector falls back to an unconditional poll (fail-closed). Whichever
-#      path runs, a deny in each phase must still return 403.
+#      response-body) skip the CGO intervention fetch when the process function
+#      returns CORAZA_OK, fetch it on CORAZA_INTERRUPTION, and fail closed on
+#      CORAZA_ERROR. The mandatory libcoraza >= 1.7 floor makes that return-value
+#      contract available on every supported runtime. A deny in each phase must
+#      still return 403.
 #
 # Every deny below is paired with a benign control that must pass, so a rule that
 # silently stopped matching cannot masquerade as a working negative control


### PR DESCRIPTION
## TL;DR

The connector carried a hardcoded copy of the firewall engine's "interrupted" result even though the engine already defines it. The values match today, but a future library change could make blocked requests pass without a diagnostic.

**Severity:** Medium (future fail-open risk at the rule-phase boundary)

## Result handling

`CORAZA_INTERRUPTION` is an enum value in `coraza.h`, not a preprocessor macro. The local `#ifndef` therefore fired on every build and replaced later uses with the literal `1`. Removing it binds comparisons to the value declared by the installed header.

`ngx_http_coraza_poll_after_process()` also treats a negative phase result as an internal error. Without that branch, a failed phase has no intervention to fetch and would continue uninspected. Current libcoraza 1.7 header-phase functions return only success or interruption, so this is a forward-compatible failure mode rather than a currently reachable one.

## Dead capability paths

libcoraza 1.7 or newer is enforced at configure time and again when each worker loads the library. Both bulk-header functions are required symbols. The optional-symbol checks and their unreachable per-header branches are removed; allocation, packing, and submission failures still use the existing per-header fallback.

The dynamic-library contract checks pin both bulk-header functions to required symbol loading, and the intervention-poll fixture now describes the enforced return-value contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Support now requires libcoraza 1.7.0 or later.
  * Older libcoraza versions no longer load successfully.

* **Performance**
  * Request and response headers use bulk submission by default, with per-header processing retained when packing or submission fails.

* **Reliability**
  * Processing errors now fail closed with an internal server error.
  * Intervention handling uses the standardized libcoraza status results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->