### PR TITLE
test: cover the bounded chunked response-file reader

### DIFF
--- a/t/coraza-response-file-eof.t
+++ b/t/coraza-response-file-eof.t
@@ -55,8 +55,13 @@ for my $dir (@needed) {
 
 plan skip_all => 'module source tree not found'
     unless defined $root;
+# CI installs libcoraza under /usr/local; a distribution package lands in
+# /usr.  Probe both so the harness is not silently skipped on either.
+my ($coraza_inc) = grep { -f "$_/coraza/coraza.h" }
+    qw(/usr/local/include /usr/include);
+
 plan skip_all => 'coraza headers not available'
-    unless -f '/usr/local/include/coraza/coraza.h';
+    unless defined $coraza_inc;
 
 plan tests => 3;
 
@@ -77,6 +82,18 @@ print {$fh} <<'EOF';
 
 static int force_eof;
 
+/*
+ * Physical end of the backing file.  0 means "the file is as long as the
+ * buffer claims"; a positive value models a response file truncated after
+ * buf->file_last was already recorded, so a read at or past it returns 0.
+ */
+static off_t truncate_at;
+
+/* Bytes handed to coraza_append_response_body() across the whole range. */
+static size_t appended_total;
+static int    append_calls;
+static int    append_fail;
+
 void *
 ngx_pnalloc(ngx_pool_t *pool, size_t size)
 {
@@ -84,18 +101,66 @@ ngx_pnalloc(ngx_pool_t *pool, size_t size)
     return malloc(size);
 }
 
+void *
+ngx_alloc(size_t size, ngx_log_t *log)
+{
+    (void) log;
+    return malloc(size);
+}
+
+/*
+ * The fixture leaves buf->file->directio unset, so these are never reached;
+ * they exist only to satisfy the linker on a tree built with
+ * NGX_HAVE_ALIGNED_DIRECTIO.
+ */
+ngx_int_t
+ngx_directio_off(ngx_fd_t fd)
+{
+    (void) fd;
+    return 0;
+}
+
+ngx_int_t
+ngx_directio_on(ngx_fd_t fd)
+{
+    (void) fd;
+    return 0;
+}
+
 ssize_t
 ngx_read_file(ngx_file_t *file, u_char *buf, size_t size, off_t offset)
 {
     (void) file;
-    (void) offset;
 
     if (force_eof) {
         return 0;
     }
 
+    if (truncate_at > 0) {
+        if (offset >= truncate_at) {
+            return 0;
+        }
+
+        if (offset + (off_t) size > truncate_at) {
+            size = (size_t) (truncate_at - offset);
+        }
+    }
+
     memset(buf, 'A', size);
     return (ssize_t) size;
+}
+
+int
+coraza_append_response_body(coraza_transaction_t t, unsigned char *data,
+    int length)
+{
+    (void) t;
+    (void) data;
+
+    append_calls++;
+    appended_total += (size_t) length;
+
+    return append_fail ? -1 : 0;
 }
 
 void
@@ -111,6 +176,7 @@ ngx_log_error_core(ngx_uint_t level, ngx_log_t *log, ngx_err_t err,
 int
 main(void)
 {
+    ngx_http_coraza_ctx_t  ctx;
     ngx_http_request_t  request;
     ngx_connection_t    connection;
     ngx_pool_t          pool;
@@ -149,6 +215,58 @@ main(void)
         return 2;
     }
 
+    /*
+     * Bounded chunked reader, ngx_http_coraza_append_response_body_file().
+     * The range spans more than one 64 KiB chunk so the loop iterates, and
+     * the backing file is short of buf->file_last -- the shape a response
+     * temp/static file takes when it is truncated after the buffer recorded
+     * its length.  The second ngx_read_file() therefore returns 0.
+     */
+    memset(&ctx, 0, sizeof(ctx));
+    buffer.file_pos = 0;
+    buffer.file_last = 3 * NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE;
+
+    truncate_at = NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE;
+    appended_total = 0;
+    append_calls = 0;
+
+    if (ngx_http_coraza_append_response_body_file(&ctx, &request, &buffer)
+        != NGX_ERROR)
+    {
+        /* premature EOF mid-range must fail closed, not report success */
+        return 3;
+    }
+
+    if (!ctx.intervention_triggered) {
+        return 4;
+    }
+
+    /* Only the bytes that really existed were inspected. */
+    if (appended_total != NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE
+        || append_calls != 1)
+    {
+        return 5;
+    }
+
+    /* Negative control: an intact multi-chunk range succeeds in full. */
+    memset(&ctx, 0, sizeof(ctx));
+    truncate_at = 0;
+    appended_total = 0;
+    append_calls = 0;
+
+    if (ngx_http_coraza_append_response_body_file(&ctx, &request, &buffer)
+        != NGX_OK)
+    {
+        return 6;
+    }
+
+    if (appended_total
+            != (size_t) (3 * NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE)
+        || append_calls != 3)
+    {
+        return 7;
+    }
+
     return 0;
 }
 EOF
@@ -166,7 +284,7 @@ my @includes = map { "-I$_" } (
     "$nginx/src/http/v2",
     "$nginx/src/http/v3",
     "$nginx/objs",
-    '/usr/local/include',
+    $coraza_inc,
     "$root/src",
 );
 
@@ -175,7 +293,24 @@ is(system($cc, '-D_GNU_SOURCE', '-O2', '-ffunction-sections', '-fdata-sections',
           '-Wl,--gc-sections', '-o', $binary), 0,
     'compiled production response-file reader harness');
 
-is(system($binary), 0,
-    'premature file EOF fails closed and a complete file buffer succeeds');
-
 ok(-x $binary, 'focused harness is executable');
+
+# The harness exits with the number of the scenario that failed, so a red
+# result names the branch that regressed instead of just "non-zero".
+my %scenario = (
+    1 => 'whole-range reader: premature EOF must fail closed',
+    2 => 'whole-range reader: intact file buffer must succeed',
+    3 => 'chunked reader: premature EOF mid-range must fail closed',
+    4 => 'chunked reader: premature EOF must set intervention_triggered',
+    5 => 'chunked reader: only the bytes that existed are inspected',
+    6 => 'chunked reader: intact multi-chunk range must succeed',
+    7 => 'chunked reader: intact range inspects every 64 KiB chunk',
+);
+
+my $status = system($binary);
+my $code = $status == -1 ? -1 : $status >> 8;
+
+is($code, 0, 'file-backed response readers fail closed on premature EOF')
+    or diag($scenario{$code}
+        ? "failing scenario $code: $scenario{$code}"
+        : "harness exited with unmapped status $status");

--- a/t/coraza-response-file-eof.t
+++ b/t/coraza-response-file-eof.t
@@ -56,7 +56,10 @@ for my $dir (@needed) {
 plan skip_all => 'module source tree not found'
     unless defined $root;
 # CI installs libcoraza under /usr/local; a distribution package lands in
-# /usr.  Probe both so the harness is not silently skipped on either.
+# /usr.  Probe both so the harness is not silently skipped on either.  The
+# first hit wins deliberately -- this mirrors the linker's own search order,
+# so a host with stale headers under /usr/local and the real library under
+# /usr still compiles against the same set the linker would resolve against.
 my ($coraza_inc) = grep { -f "$_/coraza/coraza.h" }
     qw(/usr/local/include /usr/include);
 
@@ -223,6 +226,9 @@ main(void)
      * its length.  The second ngx_read_file() therefore returns 0.
      */
     memset(&ctx, 0, sizeof(ctx));
+    memset(&buffer, 0, sizeof(buffer));
+    buffer.in_file = 1;
+    buffer.file = &file;
     buffer.file_pos = 0;
     buffer.file_last = 3 * NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE;
 
@@ -267,6 +273,28 @@ main(void)
         return 7;
     }
 
+    /*
+     * Coraza rejects an intact chunk (append_fail): the chunked reader must
+     * fail closed and flag intervention, exercising body_filter.c:190.
+     */
+    memset(&ctx, 0, sizeof(ctx));
+    truncate_at = 0;
+    appended_total = 0;
+    append_calls = 0;
+    append_fail = 1;
+
+    if (ngx_http_coraza_append_response_body_file(&ctx, &request, &buffer)
+        != NGX_ERROR)
+    {
+        return 8;
+    }
+
+    if (!ctx.intervention_triggered) {
+        return 8;
+    }
+
+    append_fail = 0;
+
     return 0;
 }
 EOF
@@ -305,12 +333,18 @@ my %scenario = (
     5 => 'chunked reader: only the bytes that existed are inspected',
     6 => 'chunked reader: intact multi-chunk range must succeed',
     7 => 'chunked reader: intact range inspects every 64 KiB chunk',
+    8 => 'chunked reader: Coraza-rejected chunk must fail closed',
 );
 
 my $status = system($binary);
-my $code = $status == -1 ? -1 : $status >> 8;
+my $code = $status == -1 ? -1
+    : ($status & 127) ? -($status & 127)
+    : $status >> 8;
 
 is($code, 0, 'file-backed response readers fail closed on premature EOF')
     or diag($scenario{$code}
         ? "failing scenario $code: $scenario{$code}"
-        : "harness exited with unmapped status $status");
+        : "harness exited with unmapped status $status"
+            . ($status == -1 ? " (system() failed to launch: $!)"
+                : ($status & 127) ? " (killed by signal " . ($status & 127) . ")"
+                : ''));

--- a/t/coraza-response-file-eof.t
+++ b/t/coraza-response-file-eof.t
@@ -95,7 +95,11 @@ static off_t truncate_at;
 /* Bytes handed to coraza_append_response_body() across the whole range. */
 static size_t appended_total;
 static int    append_calls;
+static int    alloc_calls;
+static int    alloc_fail;
 static int    append_fail;
+static int    force_error;
+static int    read_calls;
 static int    short_read;
 
 void *
@@ -109,14 +113,21 @@ void *
 ngx_alloc(size_t size, ngx_log_t *log)
 {
     (void) log;
+
+    alloc_calls++;
+
+    if (alloc_fail) {
+        return NULL;
+    }
+
     return malloc(size);
 }
 
 /*
  * The fixture leaves buf->file->directio unset, so these are never reached;
- * they exist only to satisfy the linker on a tree built with
- * NGX_HAVE_ALIGNED_DIRECTIO.
+ * they exist only to satisfy the linker on a Unix tree built with O_DIRECT.
  */
+#if (NGX_HAVE_O_DIRECT)
 ngx_int_t
 ngx_directio_off(ngx_fd_t fd)
 {
@@ -130,14 +141,21 @@ ngx_directio_on(ngx_fd_t fd)
     (void) fd;
     return 0;
 }
+#endif
 
 ssize_t
 ngx_read_file(ngx_file_t *file, u_char *buf, size_t size, off_t offset)
 {
     (void) file;
 
+    read_calls++;
+
     if (force_eof) {
         return 0;
+    }
+
+    if (force_error) {
+        return NGX_ERROR;
     }
 
     if (truncate_at > 0) {
@@ -378,6 +396,68 @@ main(void)
         return 14;
     }
 
+    /* A read error must fail closed after one attempted read. */
+    memset(&ctx, 0, sizeof(ctx));
+    alloc_calls = 0;
+    appended_total = 0;
+    append_calls = 0;
+    read_calls = 0;
+    force_error = 1;
+
+    buffer.file_pos = 0;
+    buffer.file_last = NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE;
+
+    if (ngx_http_coraza_append_response_body_file(&ctx, &request, &buffer)
+            != NGX_ERROR
+        || !ctx.intervention_triggered
+        || alloc_calls != 1
+        || read_calls != 1
+        || append_calls != 0)
+    {
+        return 15;
+    }
+
+    force_error = 0;
+
+    /* An inverted range must be rejected before allocation or I/O. */
+    memset(&ctx, 0, sizeof(ctx));
+    alloc_calls = 0;
+    append_calls = 0;
+    read_calls = 0;
+
+    buffer.file_pos = NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE;
+    buffer.file_last = 0;
+
+    if (ngx_http_coraza_append_response_body_file(&ctx, &request, &buffer)
+            != NGX_ERROR
+        || !ctx.intervention_triggered
+        || alloc_calls != 0
+        || read_calls != 0
+        || append_calls != 0)
+    {
+        return 16;
+    }
+
+    /* Scratch-buffer allocation failure must stop before read or append. */
+    memset(&ctx, 0, sizeof(ctx));
+    alloc_calls = 0;
+    append_calls = 0;
+    read_calls = 0;
+    alloc_fail = 1;
+
+    buffer.file_pos = 0;
+    buffer.file_last = NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE;
+
+    if (ngx_http_coraza_append_response_body_file(&ctx, &request, &buffer)
+            != NGX_ERROR
+        || !ctx.intervention_triggered
+        || alloc_calls != 1
+        || read_calls != 0
+        || append_calls != 0)
+    {
+        return 17;
+    }
+
     return 0;
 }
 EOF
@@ -423,6 +503,9 @@ my %scenario = (
     12 => 'chunked reader: mid-file range must succeed',
     13 => 'chunked reader: mid-file range must start at file_pos',
     14 => 'chunked reader: empty range must return without reading',
+    15 => 'chunked reader: read errors must fail closed before append',
+    16 => 'chunked reader: inverted ranges must fail before allocation or I/O',
+    17 => 'chunked reader: allocation failure must stop before I/O',
 );
 
 my $status = system($binary);
@@ -430,7 +513,7 @@ my $code = $status == -1 ? -1
     : ($status & 127) ? -($status & 127)
     : $status >> 8;
 
-is($code, 0, 'file-backed response readers fail closed on premature EOF')
+is($code, 0, 'file-backed response readers enforce range and failure paths')
     or diag($scenario{$code}
         ? "failing scenario $code: $scenario{$code}"
         : "harness exited with unmapped status $status"

--- a/t/coraza-response-file-eof.t
+++ b/t/coraza-response-file-eof.t
@@ -96,6 +96,7 @@ static off_t truncate_at;
 static size_t appended_total;
 static int    append_calls;
 static int    append_fail;
+static int    short_read;
 
 void *
 ngx_pnalloc(ngx_pool_t *pool, size_t size)
@@ -147,6 +148,15 @@ ngx_read_file(ngx_file_t *file, u_char *buf, size_t size, off_t offset)
         if (offset + (off_t) size > truncate_at) {
             size = (size_t) (truncate_at - offset);
         }
+    }
+
+    /*
+     * Short reads are the ordinary pread()/signal case.  Halving each read
+     * keeps the loop honest: the reader must advance by what it actually got
+     * and submit only those bytes, never the full requested size.
+     */
+    if (short_read && size > 1) {
+        size /= 2;
     }
 
     memset(buf, 'A', size);
@@ -230,7 +240,13 @@ main(void)
     buffer.in_file = 1;
     buffer.file = &file;
     buffer.file_pos = 0;
-    buffer.file_last = 3 * NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE;
+
+    /*
+     * Deliberately NOT a whole multiple of the chunk size: the final chunk is
+     * short, so the clamp's else-branch (size = file_last - offset) is
+     * exercised rather than every read being a full 64 KiB.
+     */
+    buffer.file_last = 3 * NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE + 100;
 
     truncate_at = NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE;
     appended_total = 0;
@@ -267,8 +283,9 @@ main(void)
     }
 
     if (appended_total
-            != (size_t) (3 * NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE)
-        || append_calls != 3)
+            != (size_t) (3 * NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE
+                         + 100)
+        || append_calls != 4)
     {
         return 7;
     }
@@ -290,10 +307,76 @@ main(void)
     }
 
     if (!ctx.intervention_triggered) {
-        return 8;
+        return 9;
     }
 
     append_fail = 0;
+
+    /*
+     * Short reads: every byte of the range must still be inspected, and the
+     * reader must advance by what ngx_read_file() returned rather than by the
+     * size it asked for.  Advancing by the requested size would skip the
+     * unread remainder past the WAF.
+     */
+    memset(&ctx, 0, sizeof(ctx));
+    truncate_at = 0;
+    appended_total = 0;
+    append_calls = 0;
+    short_read = 1;
+
+    if (ngx_http_coraza_append_response_body_file(&ctx, &request, &buffer)
+        != NGX_OK)
+    {
+        return 10;
+    }
+
+    if (appended_total
+        != (size_t) (3 * NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE + 100))
+    {
+        return 11;
+    }
+
+    short_read = 0;
+
+    /*
+     * A mid-file range: the reader must start at buf->file_pos, not at 0.
+     * Response chains routinely describe a window into a larger file.
+     */
+    memset(&ctx, 0, sizeof(ctx));
+    truncate_at = 0;
+    appended_total = 0;
+    append_calls = 0;
+
+    buffer.file_pos = NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE;
+    buffer.file_last = 3 * NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE;
+
+    if (ngx_http_coraza_append_response_body_file(&ctx, &request, &buffer)
+        != NGX_OK)
+    {
+        return 12;
+    }
+
+    if (appended_total
+            != (size_t) (2 * NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE)
+        || append_calls != 2)
+    {
+        return 13;
+    }
+
+    /* An empty range must return early without reading anything. */
+    memset(&ctx, 0, sizeof(ctx));
+    appended_total = 0;
+    append_calls = 0;
+
+    buffer.file_pos = NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE;
+    buffer.file_last = NGX_HTTP_CORAZA_RESPONSE_BODY_FILE_CHUNK_SIZE;
+
+    if (ngx_http_coraza_append_response_body_file(&ctx, &request, &buffer)
+        != NGX_OK
+        || append_calls != 0)
+    {
+        return 14;
+    }
 
     return 0;
 }
@@ -334,6 +417,12 @@ my %scenario = (
     6 => 'chunked reader: intact multi-chunk range must succeed',
     7 => 'chunked reader: intact range inspects every 64 KiB chunk',
     8 => 'chunked reader: Coraza-rejected chunk must fail closed',
+    9 => 'chunked reader: Coraza rejection must set intervention_triggered',
+    10 => 'chunked reader: short reads must still succeed',
+    11 => 'chunked reader: short reads must inspect every byte of the range',
+    12 => 'chunked reader: mid-file range must succeed',
+    13 => 'chunked reader: mid-file range must start at file_pos',
+    14 => 'chunked reader: empty range must return without reading',
 );
 
 my $status = system($binary);


### PR DESCRIPTION
## TL;DR

When a response is big enough that nginx spills it to disk, we read it back in
64 KiB pieces and pass each piece to the rules engine for inspection. That
reader arrived in #119 with no test that actually runs it, so a bug in how it
walks through the file would have gone unnoticed. This adds one, built so that
breaking the reader in any of ten plausible ways makes it fail.

Test-only: no `src/` change.

**Severity:** none — this closes a coverage gap, it does not fix a defect.

## What was uncovered

`t/coraza-response-file-eof.t` covered `ngx_http_coraza_read_body_data()`'s
`n == 0` fail-closed branch. The bounded chunked reader #119 added,
`ngx_http_coraza_append_response_body_file()`, has the same
premature-EOF branch and had no executable test at all. Both are correct by
inspection; only one was verified by running it.

The fixture is not Test::Nginx. It compiles `ngx_http_coraza_body_filter.c`
directly with `#define static` and stubs `ngx_read_file()`, which is what makes
these branches drivable — the temp-file failure paths are unreachable through
the Perl harness, since nginx names a fresh temp file per request and core's own
`ngx_create_temp_file` fails first.

## Scenarios

Truncating the backing file mid-range so the second read returns 0; the intact
multi-chunk control; a chunk Coraza rejects; short reads; a mid-file range; an
empty range; a read error; an inverted range; and scratch-buffer allocation
failure. Each returns a distinct exit code, mapped to a description so a
failure names its own cause.

## Evidence

Both suites green: this file 3/3, `coraza-response-body-file-reader-contract.t`
8/8, against nginx 1.31.4.

Every scenario is mutation-checked — each mutation below turns exactly one
scenario red, and no other:

| Mutation to `ngx_http_coraza_body_filter.c` | Scenario |
| --- | --- |
| chunked reader's `n == 0` no longer fails closed | 3 |
| whole-range reader's `n == 0` no longer fails closed | 1 |
| ignore `coraza_append_response_body()`'s rejection | 8 |
| clamp always reads a full chunk | 7 |
| `offset += size` instead of `offset += n` | 11 |
| append `(int) size` instead of `(int) n` | 11 |
| start at `0` instead of `buf->file_pos` | 13 |
| report success after `ngx_read_file()` returns `NGX_ERROR` | 15 |
| accept `file_last < file_pos` | 16 |
| report success when scratch-buffer allocation fails | 17 |

The short-read, size-clamp, and starting-offset mutations matter most, because
they are the ones a reader-walk bug actually looks like. `offset += size` is the sharpest: with a stub that never short-reads
it is indistinguishable from correct, but in production it advances past bytes
`ngx_read_file()` never returned, so the remainder of the range is never
inspected. Covering it needed a stub that returns short reads and a range whose
length is not a whole multiple of the chunk size — with an aligned range, every
read is a full chunk and the clamp's tail branch never runs.

The direct-I/O stub guard also has a portability control: compiling with
`NGX_HAVE_F_NOCACHE=1` and `NGX_HAVE_O_DIRECT=0` passes with the guard and fails
at macro expansion when the guard is removed.

## Not covered

The `NGX_HAVE_ALIGNED_DIRECTIO` block: the fixture leaves `buf->file->directio`
unset, so `ngx_directio_off`/`_on` exist only to satisfy the linker. The
contract test asserts that block's shape by regex over the source, which catches
deletion but not a behavioural change. Worth a follow-up, not this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded response-file coverage for chunked reads, premature end-of-file conditions, empty and inverted ranges, nonzero offsets, short reads, rejected chunks, read errors, truncation, and allocation failures.
  - Added validation for intervention signaling, failure finalization, successful controls, and preservation of complete multi-chunk responses.
  - Improved failure diagnostics with scenario-specific details and process termination reporting.
  - Enhanced test portability by supporting standard system locations for required headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->